### PR TITLE
Init weights and bias of gcn using glorot and zeros

### DIFF
--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -36,8 +36,8 @@ class GCNConv(torch.nn.Module):
 
     def reset_parameters(self):
         size = self.in_channels
-        uniform(size, self.weight)
-        uniform(size, self.bias)
+        glorot(self.weight)
+        zeros(self.bias)
 
     def forward(self, x, edge_index, edge_attr=None):
         out = torch.mm(x, self.weight)

--- a/torch_geometric/nn/inits.py
+++ b/torch_geometric/nn/inits.py
@@ -9,3 +9,7 @@ def glorot(tensor):
     stdv = math.sqrt(6.0/(tensor.shape[0]+tensor.shape[1]))
     if tensor is not None:
         tensor.data.uniform_(-stdv, stdv)
+
+def zeros(tensor):
+    if tensor is not None:
+        tensor.data.zero_()

--- a/torch_geometric/nn/inits.py
+++ b/torch_geometric/nn/inits.py
@@ -1,7 +1,11 @@
 import math
 
-
 def uniform(size, tensor):
     stdv = 1.0 / math.sqrt(size)
+    if tensor is not None:
+        tensor.data.uniform_(-stdv, stdv)
+
+def glorot(tensor):
+    stdv = math.sqrt(6.0/(tensor.shape[0]+tensor.shape[1]))
     if tensor is not None:
         tensor.data.uniform_(-stdv, stdv)


### PR DESCRIPTION
As you can see in the official repo weights are initialized using glorot and bias using zeros
Check [layers.py](https://github.com/tkipf/gcn/blob/master/gcn/layers.py) (commit n. 9b8bd4b) at lines 155 and 158.

I simply added two new init functions (in the nn/init.py file) and updated the reset_parameters method of the GCNConv according to Thomas Kipf's code