### PR TITLE
Fix typo in MetaLayer and add test for it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'rdflib',
 ]
 setup_requires = ['pytest-runner']
-tests_require = ['pytest', 'pytest-cov']
+tests_require = ['pytest', 'pytest-cov', 'mock']
 
 setup(
     name='torch_geometric',

--- a/test/nn/test_meta.py
+++ b/test/nn/test_meta.py
@@ -1,0 +1,32 @@
+import unittest.mock as mock
+from torch_geometric.nn.meta import MetaLayer
+
+
+def test_MetaLayer_mock():
+    edge_model = mock.MagicMock()
+    node_model = mock.MagicMock()
+    global_model = mock.MagicMock()
+
+    for em in (edge_model, None):
+        for nm in (node_model, None):
+            for gm in (global_model, None):
+                lay = MetaLayer(edge_model=em, node_model=nm, global_model=gm)
+                out = lay(
+                    x=mock.MagicMock(),
+                    edge_index=("row", "col"),
+                    edge_attr="edge_attr",
+                    u="u",
+                    batch="batch"
+                )
+                assert isinstance(out, tuple)
+                assert len(out) == 3
+                if em is not None:
+                    em.assert_called_once()
+                if nm is not None:
+                    nm.assert_called_once()
+                if gm is not None:
+                    gm.assert_called_once()
+
+                edge_model.reset_mock()
+                node_model.reset_mock()
+                global_model.reset_mock()

--- a/test/nn/test_meta.py
+++ b/test/nn/test_meta.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+import mock
 from torch_geometric.nn.meta import MetaLayer
 
 

--- a/torch_geometric/nn/meta.py
+++ b/torch_geometric/nn/meta.py
@@ -102,6 +102,8 @@ class MetaLayer(torch.nn.Module):
 
         if self.global_model is not None:
             global_x = self.global_model(x, edge_index, edge_attr, u, batch)
+        else:
+            global_x = None
 
         return x, edge_attr, global_x
 


### PR DESCRIPTION
In `MetaLayer`, `global_x` was returned but not defined when `global_model` was None.
Added simple test for the fix.