### PR TITLE
Discrete and continuous node attributes in TUDataset

### DIFF
--- a/test/datasets/test_tu_dataset.py
+++ b/test/datasets/test_tu_dataset.py
@@ -17,7 +17,7 @@ def test_enzymes():
     dataset = TUDataset(root, 'ENZYMES')
 
     assert len(dataset) == 600
-    assert dataset.num_features == 21
+    assert dataset.num_features == 3
     assert dataset.num_classes == 6
     assert dataset.__repr__() == 'ENZYMES(600)'
 
@@ -40,7 +40,7 @@ def test_enzymes():
         assert pytest.approx(avg_num_edges, abs=1e-2) == 62.14
 
         assert len(data) == 4
-        assert list(data.x.size()) == [data.num_nodes, 21]
+        assert list(data.x.size()) == [data.num_nodes, 3]
         assert list(data.y.size()) == [data.num_graphs]
         assert data.y.max() + 1 == 6
         assert list(data.batch.size()) == [data.num_nodes]
@@ -53,7 +53,7 @@ def test_enzymes():
     loader = DenseDataLoader(dataset, batch_size=len(dataset))
     for data in loader:
         assert len(data) == 4
-        assert list(data.x.size()) == [600, 126, 21]
+        assert list(data.x.size()) == [600, 126, 3]
         assert list(data.adj.size()) == [600, 126, 126]
         assert list(data.mask.size()) == [600, 126]
         assert list(data.y.size()) == [600, 1]

--- a/torch_geometric/read/tu.py
+++ b/torch_geometric/read/tu.py
@@ -22,8 +22,10 @@ def read_tu_data(folder, prefix):
     batch = read_file(folder, prefix, 'graph_indicator', torch.long) - 1
 
     node_attributes, node_labels = None, None
+    node_attr_dim = 0
     if 'node_attributes' in names:
         node_attributes = read_file(folder, prefix, 'node_attributes')
+        node_attr_dim = 1 if len(node_attributes.shape) == 1 else node_attributes.shape[1]
     if 'node_labels' in names:
         node_labels = read_file(folder, prefix, 'node_labels', torch.long)
         node_labels = one_hot(node_labels - node_labels.min(dim=0)[0])
@@ -52,7 +54,7 @@ def read_tu_data(folder, prefix):
     data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr, y=y)
     data, slices = split(data, batch)
 
-    return data, slices
+    return data, slices, {'node_attr_dim': node_attr_dim}
 
 
 def read_file(folder, prefix, name, dtype=None):


### PR DESCRIPTION
TUDataset sometimes have both discrete and continuous (float-valued) node attributes and currently they are just concatenated. Some algorithms like Weisfeiler-Lehman (WL) Graph Kernels cannot make use of continuous node attributes. In some cases, we also may want to test algorithms with or without these node attributes to compare fairly to WL. I think it is important to address this to avoid future confusion as many people might use this toolbox to benchmark their algorithms.

1. I suggest to add flag to TUDataset to let the user decide whether to use them or not. 
2. I also would store their dimensionality since it is lost during concatenation (see https://github.com/rusty1s/pytorch_geometric/blob/eb0d7bad2f220d8ba277a17adba3f4aee6f7f72c/torch_geometric/read/tu.py#L30)

