### PR TITLE
Use torch's methods to support sparse tensors

### DIFF
--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -53,12 +53,12 @@ class GCNConv(MessagePassing):
     def forward(self, x, edge_index, edge_weight=None):
         """"""
         if edge_weight is None:
-            edge_weight = x.new_ones((edge_index.size(1), ))
+            edge_weight = torch.ones((edge_index.size(1), ), dtype=x.dtype, device=x.device)
         edge_weight = edge_weight.view(-1)
         assert edge_weight.size(0) == edge_index.size(1)
 
         edge_index = add_self_loops(edge_index, num_nodes=x.size(0))
-        loop_weight = x.new_full((x.size(0), ), 1 if not self.improved else 2)
+        loop_weight = torch.full((x.size(0), ), 1 if not self.improved else 2, dtype=x.dtype, device=x.device)
         edge_weight = torch.cat([edge_weight, loop_weight], dim=0)
 
         row, col = edge_index


### PR DESCRIPTION
If you pass a sparse matrix ([torch.sparse](https://pytorch.org/docs/stable/sparse.html)) to the `forward` method of the `GCNConv` class, you get the following runtime error:
`RuntimeError: full(...) is not implemented for sparse layout`

You can reproduce it in the following way:
```python
# Build a 2x2 (sparse) identity matrix
a = torch.sparse.LongTensor(torch.tensor([[0,1], [0,1]]), torch.ones(2))
# (Try to) build a tensor with size (2,2), filled with 1s,
# with the same torch.dtype and torch.device as a
a.new_full((2,2), 1)
```

While the `new_full()` method is not implemented for the sparse layout, one can still use the [`torch.full()`](https://pytorch.org/docs/stable/torch.html#torch.full) method, specifying the `dtype` and the `device`:
```python
# Build a 2x2 (sparse) identity matrix
a = torch.sparse.LongTensor(torch.tensor([[0,1], [0,1]]), torch.ones(2))
# Build a tensor with size (2,2), filled with 1s,
# with the same torch.dtype and torch.device as a
torch.full((2,2), 1, dtype=a.dtype, device=a.device)
```