### PR TITLE
Alternative tensor indexing in MessagePassing.

### DIFF
--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -1,6 +1,7 @@
 import inspect
 
 import torch
+import torch.nn.functional as F
 from torch_geometric.utils import scatter_
 
 
@@ -42,11 +43,13 @@ class MessagePassing(torch.nn.Module):
             if arg[-2:] == '_i':
                 tmp = kwargs[arg[:-2]]
                 size = tmp.size(0)
-                message_args.append(tmp[edge_index[0]])
+                tmp = F.embedding(edge_index[0], tmp)
+                message_args.append(tmp)
             elif arg[-2:] == '_j':
                 tmp = kwargs[arg[:-2]]
                 size = tmp.size(0)
-                message_args.append(tmp[edge_index[1]])
+                tmp = F.embedding(edge_index[1], tmp)
+                message_args.append(tmp)
             else:
                 message_args.append(kwargs[arg])
 


### PR DESCRIPTION
This addresses issue #95. Regular tensor indexing has performance issues
in the backward pass on GPU. Since `torch.nn.functional.embedding` has
better performance for equivalent behavior, this was used instead.