### PR TITLE
Fix PointCNN benchmark; sklearn is replaced by scikit-learn.

### DIFF
--- a/benchmark/points/point_cnn.py
+++ b/benchmark/points/point_cnn.py
@@ -21,13 +21,13 @@ class Net(torch.nn.Module):
     def __init__(self, num_classes):
         super(Net, self).__init__()
 
-        self.conv1 = XConv(0, 48, kernel_size=8, hidden_channels=32)
+        self.conv1 = XConv(0, 48, dim=3, kernel_size=8, hidden_channels=32)
         self.conv2 = XConv(
-            48, 96, kernel_size=12, hidden_channels=64, dilation=2)
+            48, 96, dim=3, kernel_size=12, hidden_channels=64, dilation=2)
         self.conv3 = XConv(
-            96, 192, kernel_size=16, hidden_channels=128, dilation=2)
+            96, 192, dim=3, kernel_size=16, hidden_channels=128, dilation=2)
         self.conv4 = XConv(
-            192, 384, kernel_size=16, hidden_channels=256, dilation=2)
+            192, 384, dim=3, kernel_size=16, hidden_channels=256, dilation=2)
 
         self.lin1 = Lin(384, 256)
         self.lin2 = Lin(256, 128)

--- a/benchmark/setup.py
+++ b/benchmark/setup.py
@@ -7,5 +7,5 @@ setup(
     author='Matthias Fey',
     author_email='matthias.fey@tu-dortmund.de',
     url='https://github.com/rusty1s/pytorch_geometric_benchmark',
-    install_requires=['sklearn'],
+    install_requires=['scikit-learn'],
     packages=find_packages())


### PR DESCRIPTION
Fix PointCNN benchmark (dim (int) is required); [sklearn](https://pypi.org/project/sklearn/) is replaced by [scikit-learn](https://pypi.org/project/scikit-learn/).