### PR TITLE
Tiny LineGraph improvements

### DIFF
--- a/torch_geometric/transforms/line_graph.py
+++ b/torch_geometric/transforms/line_graph.py
@@ -14,15 +14,26 @@ class LineGraph(object):
 
         \mathcal{E}^{\prime} &= \{ (e_1, e_2) : e_1 \cap e_2 \neq \emptyset \}
 
-    New node features are given by (scattered) old edge attributes.
+    For directed graphs, line graph vertex indices are equal to indices in the
+    original graph's `edge_index`. For undirected graphs, line graph vertex
+    indices are obtained by ordering `(row, col)` edges with `row < col`, so
+    that the maximum line graph vertex index is
+    `original.edge_index.size(1) // 2 - 1`.
+
+    New node features are given by (scattered) old edge attributes: for
+    undirected graphs, edge attributes for reciprocal edges `(row, col)` and
+    `(col, row)` get summed together.
+
+    If `force_directed` is `True`, the graph will be treated as a directed
+    graph even if `data.is_directed() == False`.
     """
 
-    def __call__(self, data):
+    def __call__(self, data, force_directed=False):
         N = data.num_nodes
         edge_index, edge_attr = data.edge_index, data.edge_attr
         (row, col), edge_attr = coalesce(edge_index, edge_attr, N, N)
 
-        if data.is_directed():
+        if force_directed or data.is_directed():
             i = torch.arange(row.size(0), dtype=torch.long, device=row.device)
 
             count = scatter_add(


### PR DESCRIPTION
`LineGraph()(data, force_directed=True)` forces the line graph
transform to treat the graph as being directed even if it isn't.

Also fleshed out pydoc for behavior in undirected case.