### PR TITLE
Possible subscript typo for GATConv formula

### DIFF
--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -12,7 +12,7 @@ class GATConv(MessagePassing):
     <https://arxiv.org/abs/1710.10903>`_ paper
 
     .. math::
-        \mathbf{x}^{\prime}_i = \alpha_{i,i}\mathbf{\Theta}\mathbf{x}_{j} +
+        \mathbf{x}^{\prime}_i = \alpha_{i,i}\mathbf{\Theta}\mathbf{x}_{i} +
         \sum_{j \in \mathcal{N}(i)} \alpha_{i,j}\mathbf{\Theta}\mathbf{x}_{j},
 
     where the attention coefficients :math:`\alpha_{i,j}` are computed as


### PR DESCRIPTION
I think there may be a small typo in the [`GATConv`](https://rusty1s.github.io/pytorch_geometric/build/html/_modules/torch_geometric/nn/conv/gat_conv.html#GATConv) formula in the first term where I believe the **x** vector should refer to the features of the current node _i_, and _j_ is not yet defined.