### PR TITLE
make `correct` float to avoid truncating

### DIFF
--- a/docs/source/notes/introduction.rst
+++ b/docs/source/notes/introduction.rst
@@ -402,7 +402,7 @@ Finally we can evaluate our model on the test nodes:
 
     model.eval()
     _, pred = model(data).max(dim=1)
-    correct = pred[data.test_mask].eq(data.y[data.test_mask]).sum().item()
+    correct = float (pred[data.test_mask].eq(data.y[data.test_mask]).sum().item())
     acc = correct / data.test_mask.sum().item()
     print('Accuracy: {:.4f}'.format(acc))
     >>> Accuracy: 0.8150


### PR DESCRIPTION
Without float conversion the `acc` variable always becomes `0`.