### PR TITLE
Removed checks before applying dropout.

### DIFF
--- a/benchmark/runtime/dgl/gat.py
+++ b/benchmark/runtime/dgl/gat.py
@@ -42,8 +42,7 @@ class GATConv(torch.nn.Module):
 
     def gat_reduce(self, node):
         alpha = torch.softmax(node.mailbox['a'], dim=1)
-        if self.training and self.dropout > 0:
-            alpha = F.dropout(alpha, p=self.dropout, training=True)
+        alpha = F.dropout(alpha, p=self.dropout, training=self.training)
         x = (node.mailbox['m'] * alpha.unsqueeze(-1)).sum(dim=1)
         return {'x': x}
 

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -95,8 +95,7 @@ class GATConv(MessagePassing):
         alpha = softmax(alpha, edge_index_i, num_nodes)
 
         # Sample attention coefficients stochastically.
-        if self.training and self.dropout > 0:
-            alpha = F.dropout(alpha, p=self.dropout, training=True)
+        alpha = F.dropout(alpha, p=self.dropout, training=self.training)
 
         return x_j * alpha.view(-1, self.heads, 1)
 

--- a/torch_geometric/nn/conv/hypergraph_conv.py
+++ b/torch_geometric/nn/conv/hypergraph_conv.py
@@ -137,9 +137,7 @@ class HypergraphConv(MessagePassing):
             alpha = (torch.cat([x_i, x_j], dim=-1) * self.att).sum(dim=-1)
             alpha = F.leaky_relu(alpha, self.negative_slope)
             alpha = softmax(alpha, hyperedge_index[0], x.size(0))
-
-            if self.training and self.dropout > 0:
-                alpha = F.dropout(alpha, p=self.dropout, training=True)
+            alpha = F.dropout(alpha, p=self.dropout, training=self.training)
 
         out = self.__forward__(x, hyperedge_index, hyperedge_weight, alpha)
 


### PR DESCRIPTION
These arguments are already checked before applying dropout inside [ATen](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Dropout.cpp#L44). Do we need those checks here?