### PR TITLE
Remove the need to calculate x_min_value in topK

### DIFF
--- a/torch_geometric/nn/pool/topk_pool.py
+++ b/torch_geometric/nn/pool/topk_pool.py
@@ -17,8 +17,7 @@ def topk(x, ratio, batch):
     index = torch.arange(batch.size(0), dtype=torch.long, device=x.device)
     index = (index - cum_num_nodes[batch]) + (batch * max_num_nodes)
 
-    x_min_value = x.min().item()
-    dense_x = x.new_full((batch_size * max_num_nodes, ), x_min_value - 1)
+    dense_x = x.new_full((batch_size * max_num_nodes, ), -2)
     dense_x[index] = x
     dense_x = dense_x.view(batch_size, max_num_nodes)
     _, perm = dense_x.sort(dim=-1, descending=True)
@@ -102,9 +101,9 @@ class TopKPooling(torch.nn.Module):
         x = x.unsqueeze(-1) if x.dim() == 1 else x
 
         score = (x * self.weight).sum(dim=-1)
-        score = score / self.weight.norm(p=2, dim=-1)
+        score = torch.tanh(score / self.weight.norm(p=2, dim=-1))
         perm = topk(score, self.ratio, batch)
-        x = x[perm] * torch.tanh(score[perm]).view(-1, 1)
+        x = x[perm] * score[perm].view(-1, 1)
         batch = batch[perm]
         edge_index, edge_attr = filter_adj(
             edge_index, edge_attr, perm, num_nodes=score.size(0))


### PR DESCRIPTION
The role of `x_min_value` was to prevent nodes not present in a graph from being selected in topK. This was done by setting the values in the positions outside the nodes in a graph as `x_min_value`-1. 

The PR applies `tanh` to score before passing to `topk` which bounds the scores between -1 and 1. Now by replacing `x_min_value` with -2 we achieve the same intended result.