### PR TITLE
Make GAT example code consistent with paper's implementation

### DIFF
--- a/examples/gat.py
+++ b/examples/gat.py
@@ -16,7 +16,8 @@ class Net(torch.nn.Module):
     def __init__(self):
         super(Net, self).__init__()
         self.conv1 = GATConv(dataset.num_features, 8, heads=8, dropout=0.6)
-        self.conv2 = GATConv(8 * 8, dataset.num_classes, dropout=0.6)
+        # For Pubmed, use heads=8 for conv2
+        self.conv2 = GATConv(8 * 8, dataset.num_classes, dropout=0.6, concat=False)
 
     def forward(self):
         x = F.dropout(data.x, p=0.6, training=self.training)


### PR DESCRIPTION
In GAT, the last layer uses `concat=False`. Also, specifically for Pubmed dataset, the number of heads in out layer is set to 8. So, it'll be better to have this comment for easier reproducibility of Pubmed results.