### PR TITLE
update num_node_features

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -83,9 +83,9 @@ class Dataset(torch.utils.data.Dataset):
         self._process()
 
     @property
-    def num_features(self):
+    def num_node_features(self):
         r"""Returns the number of features per node in the graph."""
-        return self[0].num_features
+        return self[0].num_node_features
 
     @property
     def raw_paths(self):


### PR DESCRIPTION
This fixes the mismatch between documentation and dataset.py.
Update dataset.py to match with the [tutorial](https://github.com/AnirudhDagar/pytorch_geometric/blame/4c05d9b86135139da24e9942ddb448b23c817f4a/docs/source/notes/introduction.rst#L139) on datasets where dataset.num_node_features replaced dataset.num_features.