### PR TITLE
Slight change to getting the keys of G.nodes

### DIFF
--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -82,7 +82,7 @@ def from_networkx(G):
     edge_index = torch.tensor(list(G.edges)).t().contiguous()
 
     keys = []
-    keys += list(G.nodes(data=True)[0].keys())
+    keys += list(list(G.nodes(data=True))[0][1].keys())
     keys += list(list(G.edges(data=True))[0][2].keys())
     data = {key: [] for key in keys}
 


### PR DESCRIPTION
May throw KeyError: 'Key 0 not found'