### PR TITLE
Update isolated.py

### DIFF
--- a/torch_geometric/utils/isolated.py
+++ b/torch_geometric/utils/isolated.py
@@ -16,5 +16,6 @@ def contains_isolated_nodes(edge_index, num_nodes=None):
     :rtype: bool
     """
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
-    (row, _), _ = remove_self_loops(edge_index)
-    return torch.unique(row).size(0) < num_nodes
+    (row, col), _ = remove_self_loops(edge_index)
+    
+    return torch.unique(torch.cat((row, col))).size(0) < num_nodes


### PR DESCRIPTION
Some connected vertex may be contained in col only and not row in line 19, so they may get lost in the count during the unique() operation. The change ensures all nodes are accounted for.