### PR TITLE
Update num_nodes.py

### DIFF
--- a/torch_geometric/utils/num_nodes.py
+++ b/torch_geometric/utils/num_nodes.py
@@ -1,2 +1,2 @@
 def maybe_num_nodes(index, num_nodes=None):
-    return index.max().item() + 1 if num_nodes is None else num_nodes
+    return len(torch.unique(torch.cat((index[0,:], index[1,:])))) if num_nodes is None else num_nodes


### PR DESCRIPTION
Original implementation assumes the edge index belongs to a graph that is not an induced subgraph. New version returns the number of unique node entries in edge_index, rather than the max node label + 1.