### PR TITLE
Add graphConv to SAGPool

### DIFF
--- a/torch_geometric/nn/pool/sag_pool.py
+++ b/torch_geometric/nn/pool/sag_pool.py
@@ -1,5 +1,5 @@
 import torch
-from torch_geometric.nn import GraphConv, GATConv, SAGEConv
+from torch_geometric.nn import GCNConv, GATConv, SAGEConv, GraphConv
 from torch_geometric.nn.pool.topk_pool import topk, filter_adj
 
 
@@ -33,20 +33,22 @@ class SAGPooling(torch.nn.Module):
             neural network layer.
     """
 
-    def __init__(self, in_channels, ratio=0.5, gnn='GCN', **kwargs):
+    def __init__(self, in_channels, ratio=0.5, gnn='gConv', **kwargs):
         super(SAGPooling, self).__init__()
 
         self.in_channels = in_channels
         self.ratio = ratio
         self.gnn_name = gnn
 
-        assert gnn in ['GCN', 'GAT', 'SAGE']
+        assert gnn in ['GCN', 'GAT', 'SAGE', 'gConv']
         if gnn == 'GCN':
-            self.gnn = GraphConv(self.in_channels, 1, **kwargs)
+            self.gnn = GCNConv(self.in_channels, 1, **kwargs)
         elif gnn == 'GAT':
             self.gnn = GATConv(self.in_channels, 1, **kwargs)
-        else:
+        elif gnn == 'SAGE':
             self.gnn = SAGEConv(self.in_channels, 1, **kwargs)
+        else:
+            self.gnn = GraphConv(self.in_channels, 1, **kwargs)
 
         self.reset_parameters()
 


### PR DESCRIPTION
There was a typo with the GCN option in the SAGPool. Instead of using GCN it was using GraphConv (as the default conv in benchmark currently is GraphConv). This PR fixes the above and also adds GraphConv as a separate option and makes it default to maintain consistency with the kernel benchmarking. 

I wasn't able to find a short form for GraphConv as  GCN is already taken :) so I have used gConv as the abbreviation. If we have to use 3 letter then GRC could be a possiblity. Please change the abbreviation if you have a better naming for GraphConv and do let me know too!