### PR TITLE
Add Readout Pooling

### DIFF
--- a/test/nn/glob/test_glob.py
+++ b/test/nn/glob/test_glob.py
@@ -27,5 +27,3 @@ def test_global_pool():
     assert out.size() == (2, 8)
     assert out[0].tolist() == torch.cat((x[:4].mean(dim=0), x[:4].max(dim=0)[0]), dim=-1).tolist()
     assert out[1].tolist() == torch.cat((x[4:].mean(dim=0), x[4:].max(dim=0)[0]), dim=-1).tolist()
-
-test_global_pool()

--- a/test/nn/glob/test_glob.py
+++ b/test/nn/glob/test_glob.py
@@ -1,6 +1,6 @@
 import torch
 from torch_geometric.nn import (global_add_pool, global_mean_pool,
-                                global_max_pool)
+                                global_max_pool, global_readout)
 
 
 def test_global_pool():
@@ -22,3 +22,10 @@ def test_global_pool():
     assert out.size() == (2, 4)
     assert out[0].tolist() == x[:4].max(dim=0)[0].tolist()
     assert out[1].tolist() == x[4:].max(dim=0)[0].tolist()
+
+    out = global_readout(x, batch)
+    assert out.size() == (2, 8)
+    assert out[0].tolist() == torch.cat((x[:4].mean(dim=0), x[:4].max(dim=0)[0]), dim=-1).tolist()
+    assert out[1].tolist() == torch.cat((x[4:].mean(dim=0), x[4:].max(dim=0)[0]), dim=-1).tolist()
+
+test_global_pool()

--- a/test/nn/pool/test_readout.py
+++ b/test/nn/pool/test_readout.py
@@ -1,0 +1,37 @@
+import torch
+from torch_geometric.data import Batch
+from torch_geometric.nn import readout_x, readout
+
+
+def test_readout_x():
+    cluster = torch.tensor([0, 1, 0, 1, 2, 2])
+    x = torch.Tensor([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]])
+    batch = torch.tensor([0, 0, 0, 0, 1, 1])
+
+    out = readout_x(cluster, x, batch)
+    assert out[0].tolist() == [[3, 4, 5, 6], [5, 6, 7, 8], [10, 11, 11, 12]]
+    assert out[1].tolist() == [0, 0, 1]
+
+    out = readout_x(cluster, x, batch, size=2)
+    assert out.tolist() == [[3, 4, 5, 6], [5, 6, 7, 8], [10, 11, 11, 12], [0, 0, 0, 0]]
+
+
+def test_readout():
+    cluster = torch.tensor([0, 1, 0, 1, 2, 2])
+    x = torch.Tensor([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]])
+    pos = torch.Tensor([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]])
+    edge_index = torch.tensor([[0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 5],
+                               [1, 2, 3, 0, 2, 3, 0, 1, 3, 0, 1, 2, 5, 4]])
+    edge_attr = torch.Tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    batch = torch.tensor([0, 0, 0, 0, 1, 1])
+
+    data = Batch(
+        x=x, pos=pos, edge_index=edge_index, edge_attr=edge_attr, batch=batch)
+
+    data = readout(cluster, data, transform=lambda x: x)
+
+    assert data.x.tolist() == [[3, 4, 5, 6], [5, 6, 7, 8], [10, 11, 11, 12]]
+    assert data.pos.tolist() == [[1, 1], [2, 2], [4.5, 4.5]]
+    assert data.edge_index.tolist() == [[0, 1], [1, 0]]
+    assert data.edge_attr.tolist() == [4, 4]
+    assert data.batch.tolist() == [0, 0, 1]

--- a/torch_geometric/nn/glob/__init__.py
+++ b/torch_geometric/nn/glob/__init__.py
@@ -1,4 +1,4 @@
-from .glob import global_add_pool, global_mean_pool, global_max_pool
+from .glob import global_add_pool, global_mean_pool, global_max_pool, global_readout
 from .sort import global_sort_pool
 from .attention import GlobalAttention
 from .set2set import Set2Set
@@ -7,6 +7,7 @@ __all__ = [
     'global_add_pool',
     'global_mean_pool',
     'global_max_pool',
+    'global_readout',
     'global_sort_pool',
     'GlobalAttention',
     'Set2Set',

--- a/torch_geometric/nn/glob/glob.py
+++ b/torch_geometric/nn/glob/glob.py
@@ -8,6 +8,7 @@ def global_add_pool(x, batch, size=None):
 
     .. math::
         \mathbf{r}_i = \sum_{n=1}^{N_i} \mathbf{x}_n
+
     Args:
         x (Tensor): Node feature matrix
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}`.
@@ -15,6 +16,7 @@ def global_add_pool(x, batch, size=None):
             B-1\}}^N`, which assigns each node to a specific example.
         size (int, optional): Batch-size :math:`B`.
             Automatically calculated if not given. (default: :obj:`None`)
+
     :rtype: :class:`Tensor`
     """
 
@@ -29,6 +31,7 @@ def global_mean_pool(x, batch, size=None):
 
     .. math::
         \mathbf{r}_i = \frac{1}{N_i} \sum_{n=1}^{N_i} \mathbf{x}_n
+
     Args:
         x (Tensor): Node feature matrix
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}`.
@@ -36,6 +39,7 @@ def global_mean_pool(x, batch, size=None):
             B-1\}}^N`, which assigns each node to a specific example.
         size (int, optional): Batch-size :math:`B`.
             Automatically calculated if not given. (default: :obj:`None`)
+
     :rtype: :class:`Tensor`
     """
 
@@ -50,6 +54,7 @@ def global_max_pool(x, batch, size=None):
 
     .. math::
         \mathbf{r}_i = \mathrm{max}_{n=1}^{N_i} \, \mathbf{x}_n
+
     Args:
         x (Tensor): Node feature matrix
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}`.
@@ -57,6 +62,7 @@ def global_max_pool(x, batch, size=None):
             B-1\}}^N`, which assigns each node to a specific example.
         size (int, optional): Batch-size :math:`B`.
             Automatically calculated if not given. (default: :obj:`None`)
+
     :rtype: :class:`Tensor`
     """
 
@@ -74,6 +80,7 @@ def global_readout(x, batch, size=None):
     .. math::
         \mathbf{r}_i = \frac{1}{N_i} \sum_{n=1}^{N_i} \mathbf{x}_n \, \Vert \, 
         \mathrm{max}_{n=1}^{N_i} \, \mathbf{x}_n
+
     Args:
         x (Tensor): Node feature matrix
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}`.
@@ -81,6 +88,7 @@ def global_readout(x, batch, size=None):
             B-1\}}^N`, which assigns each node to a specific example.
         size (int, optional): Batch-size :math:`B`.
             Automatically calculated if not given. (default: :obj:`None`)
+            
     :rtype: :class:`Tensor`
     """
 

--- a/torch_geometric/nn/glob/glob.py
+++ b/torch_geometric/nn/glob/glob.py
@@ -1,3 +1,4 @@
+import torch
 from torch_geometric.utils import scatter_
 
 
@@ -88,7 +89,7 @@ def global_readout(x, batch, size=None):
             B-1\}}^N`, which assigns each node to a specific example.
         size (int, optional): Batch-size :math:`B`.
             Automatically calculated if not given. (default: :obj:`None`)
-            
+
     :rtype: :class:`Tensor`
     """
 

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -1,5 +1,6 @@
 from .max_pool import max_pool, max_pool_x
 from .avg_pool import avg_pool, avg_pool_x
+from .readout import readout, readout_x
 from .graclus import graclus
 from .voxel_grid import voxel_grid
 from .topk_pool import TopKPooling
@@ -11,8 +12,10 @@ __all__ = [
     'SAGPooling',
     'max_pool',
     'avg_pool',
+    'readout',
     'max_pool_x',
     'avg_pool_x',
+    'readout_x',
     'graclus',
     'voxel_grid',
     'fps',

--- a/torch_geometric/nn/pool/readout.py
+++ b/torch_geometric/nn/pool/readout.py
@@ -1,3 +1,4 @@
+import torch
 from torch_geometric.data import Batch
 from torch_geometric.utils import scatter_
 
@@ -8,8 +9,8 @@ from .pool import pool_edge, pool_batch, pool_pos
 def _readout_x(cluster, x, size=None):
     return torch.cat((
         scatter_('mean', x, cluster, dim_size=size),
-        scatter_('max', x, cluster, dim_size=size),
-        dim=-1))
+        scatter_('max', x, cluster, dim_size=size)),
+        dim=-1)
 
 
 def readout_x(cluster, x, batch, size=None):

--- a/torch_geometric/nn/pool/readout.py
+++ b/torch_geometric/nn/pool/readout.py
@@ -1,0 +1,73 @@
+from torch_geometric.data import Batch
+from torch_geometric.utils import scatter_
+
+from .consecutive import consecutive_cluster
+from .pool import pool_edge, pool_batch, pool_pos
+
+
+def _readout_x(cluster, x, size=None):
+    return torch.cat((
+        scatter_('mean', x, cluster, dim_size=size),
+        scatter_('max', x, cluster, dim_size=size),
+        dim=-1))
+
+
+def readout_x(cluster, x, batch, size=None):
+    r"""Concatenates average pool and max pool of node features according 
+    to the clustering defined in :attr:`cluster`.
+    See :meth:`torch_geometric.nn.pool.max_pool_x` for more details.
+
+    Args:
+        cluster (LongTensor): Cluster vector :math:`\mathbf{c} \in \{ 0,
+            \ldots, N - 1 \}^N`, which assigns each node to a specific cluster.
+        x (Tensor): Node feature matrix
+            :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}`.
+        batch (LongTensor): Batch vector :math:`\mathbf{b} \in {\{ 0, \ldots,
+            B-1\}}^N`, which assigns each node to a specific example.
+        size (int, optional): The maximum number of clusters in a single
+            example. (default: :obj:`None`)
+
+    :rtype: (:class:`Tensor`, :class:`LongTensor`) if :attr:`size` is
+        :obj:`None`, else :class:`Tensor`
+    """
+    if size is not None:
+        return _readout_x(cluster, x, (batch.max().item() + 1) * size)
+
+    cluster, perm = consecutive_cluster(cluster)
+    x = _readout_x(cluster, x)
+    batch = pool_batch(perm, batch)
+
+    return x, batch
+
+
+def readout(cluster, data, transform=None):
+    r"""Pools and coarsens a graph given by the
+    :class:`torch_geometric.data.Data` object according to the clustering
+    defined in :attr:`cluster`.
+    Final node features are defined by the *concatenating* the *average* 
+    and *maximum* features of all nodes within the same cluster.
+    See :meth:`torch_geometric.nn.pool.max_pool` for more details.
+
+    Args:
+        cluster (LongTensor): Cluster vector :math:`\mathbf{c} \in \{ 0,
+            \ldots, N - 1 \}^N`, which assigns each node to a specific cluster.
+        data (Data): Graph data object.
+        transform (callable, optional): A function/transform that takes in the
+            coarsened and pooled :obj:`torch_geometric.data.Data` object and
+            returns a transformed version. (default: :obj:`None`)
+
+    :rtype: :class:`torch_geometric.data.Data`
+    """
+    cluster, perm = consecutive_cluster(cluster)
+
+    x = _readout_x(cluster, data.x) 
+    index, attr = pool_edge(cluster, data.edge_index, data.edge_attr)
+    batch = None if data.batch is None else pool_batch(perm, data.batch)
+    pos = None if data.pos is None else pool_pos(cluster, data.pos)
+
+    data = Batch(batch=batch, x=x, edge_index=index, edge_attr=attr, pos=pos)
+
+    if transform is not None:
+        data = transform(data)
+
+    return data


### PR DESCRIPTION
This PR adds the readout pooling from [Towards Sparse Hierarchical Graph Classifiers](https://arxiv.org/abs/1811.01287) to PyG. 

The following methods have been added:
1) `global_readout()` has been added to `glob/glob.py`.
2) `readout_x` and `readout` has been added to a new file `pool/readout.py`
3) tests and docs have also been added in the respective files.