### PR TITLE
test_permuted_global_pool: Fixed seldom-occurring (~1% of cases) assert failure

### DIFF
--- a/test/nn/glob/test_glob.py
+++ b/test/nn/glob/test_glob.py
@@ -28,25 +28,24 @@ def test_permuted_global_pool():
     N_1, N_2 = 4, 6
     x = torch.randn(N_1 + N_2, 4)
     batch = torch.cat([torch.zeros(N_1), torch.ones(N_2)]).to(torch.long)
-
     perm = torch.randperm(N_1 + N_2)
-    perm_x = x[perm]
-    perm_batch = batch[perm]
 
-    mask_N_1 = perm_batch == 0
-    mask_N_2 = perm_batch == 1
+    px = x[perm]
+    pbatch = batch[perm]
+    px1 = px[pbatch == 0]
+    px2 = px[pbatch == 1]
 
-    out = global_add_pool(perm_x, perm_batch)
+    out = global_add_pool(px, pbatch)
     assert out.size() == (2, 4)
-    assert torch.allclose(out[0], perm_x[mask_N_1].sum(dim=0))
-    assert torch.allclose(out[1], perm_x[mask_N_2].sum(dim=0))
+    assert torch.allclose(out[0], px1.sum(dim=0))
+    assert torch.allclose(out[1], px2.sum(dim=0))
 
-    out = global_mean_pool(perm_x, perm_batch)
+    out = global_mean_pool(px, pbatch)
     assert out.size() == (2, 4)
-    assert torch.allclose(out[0], perm_x[mask_N_1].mean(dim=0))
-    assert torch.allclose(out[1], perm_x[mask_N_2].mean(dim=0))
+    assert torch.allclose(out[0], px1.mean(dim=0))
+    assert torch.allclose(out[1], px2.mean(dim=0))
 
-    out = global_max_pool(perm_x, perm_batch)
+    out = global_max_pool(px, pbatch)
     assert out.size() == (2, 4)
-    assert torch.allclose(out[0], perm_x[mask_N_1].max(dim=0)[0])
-    assert torch.allclose(out[1], perm_x[mask_N_2].max(dim=0)[0])
+    assert torch.allclose(out[0], px1.max(dim=0)[0])
+    assert torch.allclose(out[1], px2.max(dim=0)[0])


### PR DESCRIPTION
The test I added yesterday failed sometimes due to numerical issues in the order of operations between the permuted and non-permuted data - I should have checked that more. Your new test fails less, but still does so in ~1% of the cases.

I've therefore updated the test to use the same order for both the global_pool operations and the operation directly on the tensor. This makes the test somewhat more ugly (since it mostly replicated the same tests as `test_global_pool`, contrary to your changes in 14b628e18fdefc250915ddc7b7b39f7880dad6cf); however, the asserts will not fail (tested with 100k iterations; my first test failed in ~10% of cases; your updated one in ~1%; this one doesn't).