### PR TITLE
aggr argument in EdgeConv

### DIFF
--- a/torch_geometric/nn/conv/edge_conv.py
+++ b/torch_geometric/nn/conv/edge_conv.py
@@ -29,7 +29,7 @@ class EdgeConv(MessagePassing):
     """
 
     def __init__(self, nn, aggr='max', **kwargs):
-        super(EdgeConv, self).__init__(aggr='max', **kwargs)
+        super(EdgeConv, self).__init__(aggr=aggr, **kwargs)
         self.nn = nn
         self.reset_parameters()
 

--- a/torch_geometric/nn/conv/edge_conv.py
+++ b/torch_geometric/nn/conv/edge_conv.py
@@ -38,7 +38,6 @@ class EdgeConv(MessagePassing):
 
     def forward(self, x, edge_index):
         """"""
-        row, col = edge_index
         x = x.unsqueeze(-1) if x.dim() == 1 else x
 
         return self.propagate(edge_index, x=x)


### PR DESCRIPTION
The parameter can't be passed because it is hard-coded in the call to __init__ of the base class.