### PR TITLE
Make each dataset to be downloaded into its own folder

### DIFF
--- a/torch_geometric/datasets/tu_dataset.py
+++ b/torch_geometric/datasets/tu_dataset.py
@@ -73,12 +73,12 @@ class TUDataset(InMemoryDataset):
     @property
     def raw_dir(self):
         name = 'raw{}'.format('_cleaned' if self.cleaned else '')
-        return osp.join(self.root, name)
+        return osp.join(self.root, self.name, name)
 
     @property
     def processed_dir(self):
         name = 'processed{}'.format('_cleaned' if self.cleaned else '')
-        return osp.join(self.root, name)
+        return osp.join(self.root, self.name, name)
 
     @property
     def num_node_labels(self):
@@ -121,11 +121,12 @@ class TUDataset(InMemoryDataset):
 
     def download(self):
         url = self.cleaned_url if self.cleaned else self.url
-        path = download_url('{}/{}.zip'.format(url, self.name), self.root)
-        extract_zip(path, self.root)
+        folder = osp.join(self.root, self.name)
+        path = download_url('{}/{}.zip'.format(url, self.name), folder)
+        extract_zip(path, folder)
         os.unlink(path)
         shutil.rmtree(self.raw_dir)
-        os.rename(osp.join(self.root, self.name), self.raw_dir)
+        os.rename(osp.join(folder, self.name), self.raw_dir)
 
     def process(self):
         self.data, self.slices = read_tu_data(self.raw_dir, self.name)


### PR DESCRIPTION
If we try to download two different TU datasets into the same folder, we will get behavior that I find not intuitive. Consider: 

    root = './'
    dataset = TUDataset(root, 'ENZYMES')
    print(dataset)
    >>> ENZYMES(600) # correct 

    dataset = TUDataset(root, 'MUTAG')
    print(dataset)
    >>> MUTAG(600) # wrong, should be MUTAG(188)

This happens because a data set is downloaded into a root folder and if a new data set is asked to be downloaded into the same folder, it will reuse the files that are already there and not download a new data set. 

Current solution to this is to use different root folders: 

    root = './ENZYMES'
    dataset = TUDataset(root, 'ENZYMES')
    print(dataset)
    >>> ENZYMES(600) # correct 

    root = './MUTAG'
    dataset = TUDataset(root, 'MUTAG')
    print(dataset)
    >>> MUTAG(188) correct

But this is not intuitive and can be easily overlooked, especially if you don't make any inspection of the downloaded data sets (e.g. knowing the number of graphs and comparing to the number in the code). The error will not be raised and you can work with the data set if it was the right one, but in fact the content of this data set will be completely taken from the first data set. 

Instead, I propose to use a separate folder for each data set name. For example: 

    root = './'
    dataset = TUDataset(root, 'ENZYMES')

will store data set under `./ENZYMES` and so when MUTAG will be used: 

    root = './'
    dataset = TUDataset(root, 'MUTAG')

it will store files under `./MUTAG`. 

I found this less error-prone and expected behavior. What do you think? 

