### PR TITLE
Add GDC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ alpha/
 *.egg-info/
 .coverage
 .coverage.*
+.vscode
 
 !torch_geometric/data/
 !test/data/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ In detail, the following methods are currently implemented:
 * **[RENet](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.models.RENet)** from Jin *et al.*: [Recurrent Event Network for Reasoning over Temporal Knowledge Graphs](https://arxiv.org/abs/1904.05530) (ICLR-W 2019)
 * **[GraphUNet](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.models.GraphUNet)** from Gao and Ji: [Graph U-Nets](https://arxiv.org/abs/1905.05178) (ICML 2019)
 * **[NeighborSampler](https://pytorch-geometric.readthedocs.io/en/latest/modules/data.html#torch_geometric.data.NeighborSampler)** from Hamilton *et al.*: [Inductive Representation Learning on Large Graphs](https://arxiv.org/abs/1706.02216) (NIPS 2017)
+* **[GDC](https://pytorch-geometric.readthedocs.io/en/latest/modules/transforms.html#torch_geometric.transforms.gdc)** from Klicpera *et al.*: [Diffusion Improves Graph Learning](https://arxiv.org/abs/1911.05485) (NeurIPS 2019)
 
 --------------------------------------------------------------------------------
 

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -20,7 +20,7 @@ if args.use_gdc:
     gdc = T.GDC(self_loop_weight=1,
                 normalization_in='sym', normalization_out='col',
                 diffusion_kwargs=dict(method='ppr', alpha=0.05),
-                sparsification_kwargs=dict(method='topk', k=128),
+                sparsification_kwargs=dict(method='topk', k=128, dim=0),
                 exact=True)
     data = gdc(data)
 

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -20,6 +20,9 @@ class Net(torch.nn.Module):
         # self.conv1 = ChebConv(data.num_features, 16, K=2)
         # self.conv2 = ChebConv(16, data.num_features, K=2)
 
+        self.reg_params = self.conv1.parameters()
+        self.non_reg_params = self.conv2.parameters()
+
     def forward(self):
         x, edge_index = data.x, data.edge_index
         x = F.relu(self.conv1(x, edge_index))
@@ -30,7 +33,9 @@ class Net(torch.nn.Module):
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model, data = Net().to(device), data.to(device)
-optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=5e-4)
+optimizer = torch.optim.Adam([dict(params=model.reg_params, weight_decay=5e-4),
+                              dict(params=model.non_reg_params, weight_decay=0)],
+                             lr=0.01)
 
 
 def train():

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import argparse
 
 import torch
 import torch.nn.functional as F
@@ -6,17 +7,29 @@ from torch_geometric.datasets import Planetoid
 import torch_geometric.transforms as T
 from torch_geometric.nn import GCNConv, ChebConv  # noqa
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--use_gdc', action='store_true', help='Use GDC preprocessing.')
+args = parser.parse_args()
+
 dataset = 'Cora'
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset)
 dataset = Planetoid(path, dataset, T.NormalizeFeatures())
 data = dataset[0]
 
+if args.use_gdc:
+    gdc = T.GDC(self_loop_weight=1,
+                normalization_in='sym', normalization_out='col',
+                diffusion_kwargs=dict(method='ppr', alpha=0.05),
+                sparsification_kwargs=dict(method='topk', k=128),
+                exact=True)
+    data = gdc(data)
+
 
 class Net(torch.nn.Module):
     def __init__(self):
         super(Net, self).__init__()
-        self.conv1 = GCNConv(dataset.num_features, 16, cached=True)
-        self.conv2 = GCNConv(16, dataset.num_classes, cached=True)
+        self.conv1 = GCNConv(dataset.num_features, 16, cached=True, normalize=not args.use_gdc)
+        self.conv2 = GCNConv(16, dataset.num_classes, cached=True, normalize=not args.use_gdc)
         # self.conv1 = ChebConv(data.num_features, 16, K=2)
         # self.conv2 = ChebConv(16, data.num_features, K=2)
 
@@ -24,10 +37,10 @@ class Net(torch.nn.Module):
         self.non_reg_params = self.conv2.parameters()
 
     def forward(self):
-        x, edge_index = data.x, data.edge_index
-        x = F.relu(self.conv1(x, edge_index))
+        x, edge_index, edge_weight = data.x, data.edge_index, data.edge_attr
+        x = F.relu(self.conv1(x, edge_index, edge_weight))
         x = F.dropout(x, training=self.training)
-        x = self.conv2(x, edge_index)
+        x = self.conv2(x, edge_index, edge_weight)
         return F.log_softmax(x, dim=1)
 
 

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -8,7 +8,8 @@ import torch_geometric.transforms as T
 from torch_geometric.nn import GCNConv, ChebConv  # noqa
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--use_gdc', action='store_true', help='Use GDC preprocessing.')
+parser.add_argument('--use_gdc', action='store_true',
+                    help='Use GDC preprocessing.')
 args = parser.parse_args()
 
 dataset = 'Cora'
@@ -17,19 +18,21 @@ dataset = Planetoid(path, dataset, T.NormalizeFeatures())
 data = dataset[0]
 
 if args.use_gdc:
-    gdc = T.GDC(self_loop_weight=1,
-                normalization_in='sym', normalization_out='col',
+    gdc = T.GDC(self_loop_weight=1, normalization_in='sym',
+                normalization_out='col',
                 diffusion_kwargs=dict(method='ppr', alpha=0.05),
-                sparsification_kwargs=dict(method='topk', k=128, dim=0),
-                exact=True)
+                sparsification_kwargs=dict(method='topk', k=128,
+                                           dim=0), exact=True)
     data = gdc(data)
 
 
 class Net(torch.nn.Module):
     def __init__(self):
         super(Net, self).__init__()
-        self.conv1 = GCNConv(dataset.num_features, 16, cached=True, normalize=not args.use_gdc)
-        self.conv2 = GCNConv(16, dataset.num_classes, cached=True, normalize=not args.use_gdc)
+        self.conv1 = GCNConv(dataset.num_features, 16, cached=True,
+                             normalize=not args.use_gdc)
+        self.conv2 = GCNConv(16, dataset.num_classes, cached=True,
+                             normalize=not args.use_gdc)
         # self.conv1 = ChebConv(data.num_features, 16, K=2)
         # self.conv2 = ChebConv(16, data.num_features, K=2)
 
@@ -46,9 +49,10 @@ class Net(torch.nn.Module):
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model, data = Net().to(device), data.to(device)
-optimizer = torch.optim.Adam([dict(params=model.reg_params, weight_decay=5e-4),
-                              dict(params=model.non_reg_params, weight_decay=0)],
-                             lr=0.01)
+optimizer = torch.optim.Adam([
+    dict(params=model.reg_params, weight_decay=5e-4),
+    dict(params=model.non_reg_params, weight_decay=0)
+], lr=0.01)
 
 
 def train():

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ __version__ = '1.3.2'
 url = 'https://github.com/rusty1s/pytorch_geometric'
 
 install_requires = [
+    'torch',
     'numpy',
     'scipy',
     'networkx',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = [
     'networkx',
     'scikit-learn',
     'scikit-image',
+    'numba',
     'requests',
     'plyfile',
     'pandas',

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -34,14 +34,28 @@ def test_gdc():
     data = Data(edge_index=edge_index, num_nodes=5)
     gdc = GDC(self_loop_weight=1,
               normalization_in='col', normalization_out='col',
-              diffusion_kwargs=dict(method='heat', t=5),
-              sparsification_kwargs=dict(method='topk', k=2),
+              diffusion_kwargs=dict(method='heat', t=10),
+              sparsification_kwargs=dict(method='topk', k=2, dim=0),
               exact=True)
     data = gdc(data)
     mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
     col_sum = mat.sum(0)
     assert np.all(mat >= -1e-8)
     assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))
+    assert np.all((~np.isclose(mat, 0)).sum(0) == 2)
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
+              normalization_in='row', normalization_out='row',
+              diffusion_kwargs=dict(method='heat', t=5),
+            sparsification_kwargs=dict(method='topk', k=2, dim=1),
+              exact=True)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    row_sum = mat.sum(1)
+    assert np.all(mat >= -1e-8)
+    assert np.all(np.isclose(row_sum, 1) | np.isclose(row_sum, 0))
+    assert np.all((~np.isclose(mat, 0)).sum(1) == 2)
 
     data = Data(edge_index=edge_index, num_nodes=5)
     gdc = GDC(self_loop_weight=1,

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -1,0 +1,58 @@
+import numpy as np
+import torch
+from torch_geometric.data import Data
+from torch_geometric.transforms import GDC
+from torch_geometric.utils import to_dense_adj
+
+
+def test_gdc():
+    edge_index = torch.tensor([[0, 0, 1, 1, 2, 2, 2, 3, 3, 4],
+                               [1, 2, 0, 2, 0, 1, 3, 2, 4, 3]])
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
+              normalization_in='sym', normalization_out='sym',
+              diffusion_kwargs=dict(method='ppr', alpha=0.15),
+              sparsification_kwargs=dict(method='threshold', avg_degree=2),
+              exact=True)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    assert np.all(mat >= 0)
+    assert np.all(mat == mat.T)
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
+              normalization_in='col', normalization_out='col',
+              diffusion_kwargs=dict(method='heat', t=5),
+              sparsification_kwargs=dict(method='topk', k=2),
+              exact=True)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    col_sum = mat.sum(0)
+    assert np.all(mat >= 0)
+    assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
+              normalization_in='row', normalization_out='row',
+              diffusion_kwargs=dict(method='coeff', coeffs=[0.8, 0.3, 0.1]),
+              sparsification_kwargs=dict(method='threshold', eps=0.1),
+              exact=True)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    row_sum = mat.sum(1)
+    assert np.all(mat >= 0)
+    assert np.all(np.isclose(row_sum, 1) | np.isclose(row_sum, 0))
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
+              normalization_in='sym', normalization_out='col',
+              diffusion_kwargs=dict(method='ppr', alpha=0.15, eps=1e-4),
+              sparsification_kwargs=dict(method='threshold', avg_degree=2),
+              exact=False)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    col_sum = mat.sum(0)
+    assert np.all(mat >= 0)
+    assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 from torch_geometric.data import Data
 from torch_geometric.transforms import GDC
@@ -10,74 +9,81 @@ def test_gdc():
                                [1, 2, 0, 2, 0, 1, 3, 2, 4, 3]])
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='sym', normalization_out='sym',
+    gdc = GDC(self_loop_weight=1, normalization_in='sym',
+              normalization_out='sym',
               diffusion_kwargs=dict(method='ppr', alpha=0.15),
-              sparsification_kwargs=dict(method='threshold', avg_degree=2),
-              exact=True)
+              sparsification_kwargs=dict(method='threshold',
+                                         avg_degree=2), exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
-    assert np.all(mat >= -1e-8)
-    assert np.allclose(mat, mat.T)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
+    assert torch.all(mat >= -1e-8)
+    assert torch.allclose(mat, mat.t())
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='sym', normalization_out='sym',
+    gdc = GDC(self_loop_weight=1, normalization_in='sym',
+              normalization_out='sym',
               diffusion_kwargs=dict(method='heat', t=10),
-              sparsification_kwargs=dict(method='threshold', avg_degree=2),
-              exact=True)
+              sparsification_kwargs=dict(method='threshold',
+                                         avg_degree=2), exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
-    assert np.all(mat >= -1e-8)
-    assert np.allclose(mat, mat.T)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
+    assert torch.all(mat >= -1e-8)
+    assert torch.allclose(mat, mat.t())
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='col', normalization_out='col',
+    gdc = GDC(self_loop_weight=1, normalization_in='col',
+              normalization_out='col',
               diffusion_kwargs=dict(method='heat', t=10),
-              sparsification_kwargs=dict(method='topk', k=2, dim=0),
-              exact=True)
+              sparsification_kwargs=dict(method='topk', k=2,
+                                         dim=0), exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
     col_sum = mat.sum(0)
-    assert np.all(mat >= -1e-8)
-    assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))
-    assert np.all((~np.isclose(mat, 0)).sum(0) == 2)
+    assert torch.all(mat >= -1e-8)
+    assert torch.all(
+        torch.isclose(col_sum, torch.tensor(1.0))
+        | torch.isclose(col_sum, torch.tensor(0.0)))
+    assert torch.all((~torch.isclose(mat, torch.tensor(0.0))).sum(0) == 2)
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='row', normalization_out='row',
+    gdc = GDC(self_loop_weight=1, normalization_in='row',
+              normalization_out='row',
               diffusion_kwargs=dict(method='heat', t=5),
-            sparsification_kwargs=dict(method='topk', k=2, dim=1),
-              exact=True)
+              sparsification_kwargs=dict(method='topk', k=2,
+                                         dim=1), exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
     row_sum = mat.sum(1)
-    assert np.all(mat >= -1e-8)
-    assert np.all(np.isclose(row_sum, 1) | np.isclose(row_sum, 0))
-    assert np.all((~np.isclose(mat, 0)).sum(1) == 2)
+    assert torch.all(mat >= -1e-8)
+    assert torch.all(
+        torch.isclose(row_sum, torch.tensor(1.0))
+        | torch.isclose(row_sum, torch.tensor(0.0)))
+    assert torch.all((~torch.isclose(mat, torch.tensor(0.0))).sum(1) == 2)
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='row', normalization_out='row',
+    gdc = GDC(self_loop_weight=1, normalization_in='row',
+              normalization_out='row',
               diffusion_kwargs=dict(method='coeff', coeffs=[0.8, 0.3, 0.1]),
-              sparsification_kwargs=dict(method='threshold', eps=0.1),
-              exact=True)
+              sparsification_kwargs=dict(method='threshold',
+                                         eps=0.1), exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
     row_sum = mat.sum(1)
-    assert np.all(mat >= -1e-8)
-    assert np.all(np.isclose(row_sum, 1) | np.isclose(row_sum, 0))
+    assert torch.all(mat >= -1e-8)
+    assert torch.all(
+        torch.isclose(row_sum, torch.tensor(1.0))
+        | torch.isclose(row_sum, torch.tensor(0.0)))
 
     data = Data(edge_index=edge_index, num_nodes=5)
-    gdc = GDC(self_loop_weight=1,
-              normalization_in='sym', normalization_out='col',
+    gdc = GDC(self_loop_weight=1, normalization_in='sym',
+              normalization_out='col',
               diffusion_kwargs=dict(method='ppr', alpha=0.15, eps=1e-4),
-              sparsification_kwargs=dict(method='threshold', avg_degree=2),
-              exact=False)
+              sparsification_kwargs=dict(method='threshold',
+                                         avg_degree=2), exact=False)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
     col_sum = mat.sum(0)
-    assert np.all(mat >= -1e-8)
-    assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))
+    assert torch.all(mat >= -1e-8)
+    assert torch.all(
+        torch.isclose(col_sum, torch.tensor(1.0))
+        | torch.isclose(col_sum, torch.tensor(0.0)))

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -22,6 +22,17 @@ def test_gdc():
 
     data = Data(edge_index=edge_index, num_nodes=5)
     gdc = GDC(self_loop_weight=1,
+              normalization_in='sym', normalization_out='sym',
+              diffusion_kwargs=dict(method='heat', t=10),
+              sparsification_kwargs=dict(method='threshold', avg_degree=2),
+              exact=True)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    assert np.all(mat >= -1e-8)
+    assert np.allclose(mat, mat.T)
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1,
               normalization_in='col', normalization_out='col',
               diffusion_kwargs=dict(method='heat', t=5),
               sparsification_kwargs=dict(method='topk', k=2),

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -16,9 +16,9 @@ def test_gdc():
               sparsification_kwargs=dict(method='threshold', avg_degree=2),
               exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
-    assert np.all(mat >= 0)
-    assert np.all(mat == mat.T)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    assert np.all(mat >= -1e-8)
+    assert np.allclose(mat, mat.T)
 
     data = Data(edge_index=edge_index, num_nodes=5)
     gdc = GDC(self_loop_weight=1,
@@ -27,9 +27,9 @@ def test_gdc():
               sparsification_kwargs=dict(method='topk', k=2),
               exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
     col_sum = mat.sum(0)
-    assert np.all(mat >= 0)
+    assert np.all(mat >= -1e-8)
     assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))
 
     data = Data(edge_index=edge_index, num_nodes=5)
@@ -39,9 +39,9 @@ def test_gdc():
               sparsification_kwargs=dict(method='threshold', eps=0.1),
               exact=True)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
     row_sum = mat.sum(1)
-    assert np.all(mat >= 0)
+    assert np.all(mat >= -1e-8)
     assert np.all(np.isclose(row_sum, 1) | np.isclose(row_sum, 0))
 
     data = Data(edge_index=edge_index, num_nodes=5)
@@ -51,8 +51,8 @@ def test_gdc():
               sparsification_kwargs=dict(method='threshold', avg_degree=2),
               exact=False)
     data = gdc(data)
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
-    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze().cpu().numpy()
     col_sum = mat.sum(0)
-    assert np.all(mat >= 0)
+    assert np.all(mat >= -1e-8)
     assert np.all(np.isclose(col_sum, 1) | np.isclose(col_sum, 0))

--- a/test/utils/test_undirected.py
+++ b/test/utils/test_undirected.py
@@ -5,8 +5,12 @@ from torch_geometric.utils import is_undirected, to_undirected
 def test_is_undirected():
     row = torch.tensor([0, 1, 0])
     col = torch.tensor([1, 0, 0])
+    sym_weight = torch.tensor([0, 0, 1])
+    asym_weight = torch.tensor([0, 1, 1])
 
     assert is_undirected(torch.stack([row, col], dim=0))
+    assert is_undirected(torch.stack([row, col], dim=0), sym_weight)
+    assert not is_undirected(torch.stack([row, col], dim=0), asym_weight)
 
     row = torch.tensor([0, 1, 1])
     col = torch.tensor([1, 0, 2])

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -248,7 +248,7 @@ class Data(object):
 
     def is_undirected(self):
         r"""Returns :obj:`True`, if graph edges are undirected."""
-        return is_undirected(self.edge_index, self.num_nodes)
+        return is_undirected(self.edge_index, self.edge_attr, self.num_nodes)
 
     def is_directed(self):
         r"""Returns :obj:`True`, if graph edges are directed."""

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -98,7 +98,8 @@ class GCNConv(MessagePassing):
             self.cached_num_edges = edge_index.size(1)
             if self.normalize:
                 edge_index, norm = self.norm(edge_index, x.size(self.node_dim),
-                                             edge_weight, self.improved, x.dtype)
+                                             edge_weight, self.improved,
+                                             x.dtype)
             else:
                 norm = edge_weight
             self.cached_result = edge_index, norm
@@ -108,7 +109,7 @@ class GCNConv(MessagePassing):
         return self.propagate(edge_index, x=x, norm=norm)
 
     def message(self, x_j, norm):
-        return norm.view(-1, 1) * x_j
+        return norm.view(-1, 1) * x_j if norm is not None else x_j
 
     def update(self, aggr_out):
         if self.bias is not None:

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -34,17 +34,20 @@ class GCNConv(MessagePassing):
             learning scenarios. (default: :obj:`False`)
         bias (bool, optional): If set to :obj:`False`, the layer will not learn
             an additive bias. (default: :obj:`True`)
+        normalize (bool, optional): Whether to add self-loops and apply
+            symmetric normalization. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
     def __init__(self, in_channels, out_channels, improved=False, cached=False,
-                 bias=True, **kwargs):
+                 bias=True, normalize=True, **kwargs):
         super(GCNConv, self).__init__(aggr='add', **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.improved = improved
         self.cached = cached
+        self.normalize = normalize
 
         self.weight = Parameter(torch.Tensor(in_channels, out_channels))
 
@@ -93,8 +96,11 @@ class GCNConv(MessagePassing):
 
         if not self.cached or self.cached_result is None:
             self.cached_num_edges = edge_index.size(1)
-            edge_index, norm = self.norm(edge_index, x.size(self.node_dim),
-                                         edge_weight, self.improved, x.dtype)
+            if self.normalize:
+                edge_index, norm = self.norm(edge_index, x.size(self.node_dim),
+                                             edge_weight, self.improved, x.dtype)
+            else:
+                norm = edge_weight
             self.cached_result = edge_index, norm
 
         edge_index, norm = self.cached_result

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -33,6 +33,7 @@ from .laplacian_lambda_max import LaplacianLambdaMax
 from .generate_mesh_normals import GenerateMeshNormals
 from .delaunay import Delaunay
 from .to_superpixels import ToSLIC
+from .gdc import GDC
 
 __all__ = [
     'Compose',
@@ -70,4 +71,5 @@ __all__ = [
     'GenerateMeshNormals',
     'Delaunay',
     'ToSLIC',
+    'GDC'
 ]

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -71,5 +71,5 @@ __all__ = [
     'GenerateMeshNormals',
     'Delaunay',
     'ToSLIC',
-    'GDC'
+    'GDC',
 ]

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -11,9 +11,9 @@ class GDC(object):
     r"""Preprocesses the graph via Graph Diffusion Convolution (GDC).
 
     As proposed in `"Diffusion Improves Graph Learning"
-    <https://arxiv.org/abs/1911.05485>`_.
+    <https://www.kdd.in.tum.de/gdc>`_.
     Johannes Klicpera, Stefan Weißenberger, Stephan Günnemann
-    NeurIPS 2019, see www.kdd.in.tum.de/gdc
+    NeurIPS 2019
 
     The paper offers additional advice on how to choose the hyperparameters.
     For an example of using GCN with GDC, see :source:`examples/gcn.py`.

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -1,0 +1,449 @@
+import numba
+import numpy as np
+import torch
+from torch_geometric.utils import add_self_loops, is_undirected, to_dense_adj
+from torch_sparse import coalesce, spspmm
+
+
+class GDC(object):
+    r"""Preprocesses the graph via Graph Diffusion Convolution (GDC).
+
+    As proposed in Diffusion Improves Graph Learning.
+    Johannes Klicpera, Stefan Weißenberger, Stephan Günnemann
+    NeurIPS 2019, see www.kdd.in.tum.de/gdc
+
+    Args:
+        self_loop_weight (float, optional): Weight of the added self-loop.
+            Set to :obj:`None` to add no self-loops. (default: :obj:`1`)
+        normalization_in (str, optional): Normalization of the transition matrix
+            on the original (input) graph. Possible values: `sym`, `col`, and `row`.
+            See :func:`GDC._transition_matrix` for details. (default: :obj:`"sym"`)
+        normalization_out (str, optional): Normalization of the transition matrix
+            on the transformed GDC (output) graph. Possible values: `sym`, `col`, and `row`.
+            See :func:`GDC._transition_matrix` for details. (default: :obj:`"col"`)
+        diffusion_kwargs (dict, optional): Dictionary containing the parameters for diffusion.
+            `method` specifies the diffusion method (values: `ppr`, `heat`, `coeff`).
+            Each diffusion method requires different additional parameters.
+            See :func:`GDC._diffusion_matrix_exact` or :func:`GDC._diffusion_matrix_approx` for details.
+            (default: :obj:`dict(method='ppr', alpha=0.15, eps=1e-4)`)
+        sparsification_kwargs (dict, optional): Dictionary containing the parameters for sparsification.
+            `method` specifies the sparsification method (values: `threshold`, `topk`).
+            Each sparsification method requires different additional parameters.
+            See :func:`GDC._sparsify_dense` for details.
+            (default: :obj:`dict(method='threshold', avg_degree=64)`)
+        exact (bool, optional): Whether to exactly calculate the diffusion matrix.
+            Note that the exact variants are not scalable. They densify the adjacency matrix
+            and calculate either its inverse or its matrix exponential.
+            However, the approximate variants do not support edge weights
+            and currently only personalized PageRank and sparsification by threshold
+            are implemented as fast, approximate versions. (default: :obj:`False`)
+
+    :rtype: :class:`torch_geometric.data.Data`
+    """
+
+    def __init__(self, self_loop_weight=1,
+                 normalization_in='sym', normalization_out='col',
+                 diffusion_kwargs=dict(method='ppr', alpha=0.15, eps=1e-4),
+                 sparsification_kwargs=dict(method='threshold', avg_degree=64),
+                 exact=False):
+        self.self_loop_weight = self_loop_weight
+        self.normalization_in = normalization_in
+        self.normalization_out = normalization_out
+        self.diffusion_kwargs = diffusion_kwargs
+        self.sparsification_kwargs = sparsification_kwargs
+        self.exact = exact
+
+        if self_loop_weight:
+            assert exact or self_loop_weight == 1
+
+    @torch.no_grad()
+    def __call__(self, data):
+        N = data.num_nodes
+        edge_index = data.edge_index
+        if data.edge_attr is None:
+            edge_weight = torch.ones(edge_index.size(1), device=edge_index.device)
+        else:
+            edge_weight = data.edge_attr
+            assert self.exact
+            assert edge_weight.dim() == 1
+
+        if self.self_loop_weight:
+            edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
+                                                     fill_value=self.self_loop_weight,
+                                                     num_nodes=N)
+
+        edge_index, edge_weight = coalesce(edge_index, edge_weight, N, N)
+
+        if self.exact:
+            edge_index, edge_weight = self._transition_matrix(edge_index, edge_weight, N, self.normalization_in)
+            diff_mat = self._diffusion_matrix_exact(edge_index, edge_weight, N, **self.diffusion_kwargs)
+            edge_index, edge_weight = self._sparsify_dense(diff_mat, **self.sparsification_kwargs)
+        else:
+            edge_index, edge_weight = self._diffusion_matrix_approx(edge_index, edge_weight, N,
+                                                                    self.normalization_in, **self.diffusion_kwargs)
+            edge_index, edge_weight = self._sparsify_sparse(edge_index, edge_weight, N, **self.sparsification_kwargs)
+
+        edge_index, edge_weight = coalesce(edge_index, edge_weight, N, N)
+        edge_index, edge_weight = self._transition_matrix(edge_index, edge_weight, N, self.normalization_out)
+
+        data.edge_index = edge_index
+        data.edge_attr = edge_weight
+
+        return data
+
+    def _transition_matrix(self, edge_index, edge_weight, num_nodes, normalization):
+        r"""Calculate the approximate, sparse diffusion on a given sparse matrix.
+
+        Args:
+            edge_index (LongTensor): The edge indices.
+            edge_weight (Tensor): One-dimensional edge weights.
+            num_nodes (int): Number of nodes.
+            normalization (str): Normalization scheme. Options:
+                1. `"sym"`: Symmetric normalization:
+                :math:`\mathbf{T} = \mathbf{D}^{-1/2} \mathbf{A}
+                \mathbf{D}^{-1/2}`
+
+                2. `"col"`: Column-wise normalization:
+                :math:`\mathbf{T} = \mathbf{A} \mathbf{D}^{-1}`
+
+                3. `"row"`: Row-wise normalization:
+                :math:`\mathbf{T} = \mathbf{D}^{-1} \mathbf{A}`
+
+        :rtype: (:class:`LongTensor`, :class:`Tensor`)
+        """
+        sp_adj_matrix = torch.sparse.FloatTensor(indices=edge_index,
+                                                 values=edge_weight,
+                                                 size=(num_nodes, num_nodes))
+        diag_idx = torch.arange(0, num_nodes, dtype=torch.long,
+                                device=edge_index.device)
+        diag_idx = diag_idx.unsqueeze(0).repeat(2, 1)
+
+        if normalization == 'sym':
+            D_vec = torch.sparse.sum(sp_adj_matrix, dim=0).to_dense()
+            D_vec_invsqrt = 1 / torch.sqrt(D_vec)
+            edge_index, edge_weight = spspmm(diag_idx, D_vec_invsqrt,
+                                             edge_index, edge_weight,
+                                             num_nodes, num_nodes, num_nodes)
+            edge_index, edge_weight = spspmm(edge_index, edge_weight,
+                                             diag_idx, D_vec_invsqrt,
+                                             num_nodes, num_nodes, num_nodes)
+        elif normalization == 'col':
+            D_vec = torch.sparse.sum(sp_adj_matrix, dim=0).to_dense()
+            D_vec_inv = 1 / D_vec
+            edge_index, edge_weight = spspmm(edge_index, edge_weight,
+                                             diag_idx, D_vec_inv,
+                                             num_nodes, num_nodes, num_nodes)
+        elif normalization == 'row':
+            D_vec = torch.sparse.sum(sp_adj_matrix, dim=1).to_dense()
+            D_vec_inv = 1 / D_vec
+            edge_index, edge_weight = spspmm(diag_idx, D_vec_inv,
+                                             edge_index, edge_weight,
+                                             num_nodes, num_nodes, num_nodes)
+        else:
+            raise ValueError(f"Transition matrix normalization '{normalization}' unknown.")
+        return edge_index, edge_weight
+
+    def _diffusion_matrix_exact(self, edge_index, edge_weight, num_nodes, method, **kwargs):
+        """Calculate the (dense) diffusion on a given sparse graph.
+        Note that these exact variants are not scalable. They densify the adjacency matrix
+        and calculate either its inverse or its matrix exponential.
+
+        Args:
+            edge_index (LongTensor): The edge indices.
+            edge_weight (Tensor): One-dimensional edge weights.
+            num_nodes (int): Number of nodes.
+            method (str): Diffusion method. Options:
+                1. `"ppr"`: Use personalized PageRank as diffusion.
+                Additionally expects the parameter:
+                - alpha (float): Return probability in PPR. Commonly lies in [0.05, 0.2].
+
+                2. `"heat"`: Use heat kernel diffusion.
+                Additionally expects the parameter:
+                - t (float): Time of diffusion. Commonly lies in [2, 10].
+
+                3. `"coeff"`: Freely choose diffusion coefficients.
+                Additionally expects the parameter:
+                - coeffs (List[float]): List of coefficients theta_k
+                for each power of the transition matrix (starting at 0).
+
+        :rtype: (:class:`Tensor`)
+        """
+        if method == 'ppr':
+            # α (I_n + (α - 1) A)^-1
+
+            edge_weight = (kwargs['alpha'] - 1) * edge_weight
+            edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
+                                                     fill_value=1,
+                                                     num_nodes=num_nodes)
+
+            # Densify matrix
+            mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
+
+            diff_matrix = kwargs['alpha'] * torch.inverse(mat)
+        elif method == 'heat':
+            # exp(t (A - I_n))
+
+            edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
+                                                     fill_value=-1,
+                                                     num_nodes=num_nodes)
+            edge_weight = kwargs['t'] * edge_weight
+
+            # Densify matrix
+            mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
+
+            undirected = is_undirected(edge_index, edge_weight, num_nodes)
+            diff_matrix = self._expm(mat, undirected)
+        elif method == 'coeff':
+            # Densify matrix
+            adj_matrix = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
+            mat = torch.eye(num_nodes)
+
+            diff_matrix = kwargs['coeffs'][0] * mat
+            for coeff in kwargs['coeffs'][1:]:
+                mat = mat @ adj_matrix
+                diff_matrix += coeff * mat
+        else:
+            raise ValueError(f"Exact GDC diffusion '{method}' unknown.")
+        return diff_matrix
+
+    def _diffusion_matrix_approx(self, edge_index, edge_weight, num_nodes, normalization, method, **kwargs):
+        """Calculate the approximate, sparse diffusion on a given sparse graph.
+
+        Args:
+            edge_index (LongTensor): The edge indices.
+            edge_weight (Tensor): One-dimensional edge weights.
+            num_nodes (int): Number of nodes.
+            normalization (str): Transition matrix normalization scheme (`sym`, `row`, or `col`).
+                See :func:`GDC._transition_matrix` for details.
+            method (str): Diffusion method. Options:
+                1. `"ppr"`: Use personalized PageRank as diffusion.
+                Additionally expects the parameters:
+                - alpha (float): Return probability in PPR. Commonly lies in [0.05, 0.2].
+                - eps (float): Threshold for PPR calculation stopping criterion
+                (`edge_weight` >= `eps` * `out_degree`).
+
+        :rtype: (:class:`LongTensor`, :class:`Tensor`)
+        """
+        if method == 'ppr':
+            if normalization == 'sym':
+                # Calculate original degrees
+                sp_adj_matrix = torch.sparse.FloatTensor(
+                    indices=edge_index, values=edge_weight, size=(num_nodes, num_nodes))
+                D_vec_orig = torch.sparse.sum(sp_adj_matrix, dim=0).to_dense()
+
+            edge_index_np = edge_index.numpy()
+            # Assumes coalesced edge_index
+            _, indptr, out_degree = np.unique(edge_index_np[0], return_index=True, return_counts=True)
+
+            neighbors, neighbor_weights = GDC._calc_ppr(indptr, edge_index_np[1], out_degree,
+                                                        kwargs['alpha'], kwargs['eps'])
+            ppr_normalization = 'col' if normalization == 'col' else 'row'
+            edge_index, edge_weight = self._neighbors_to_graph(neighbors, neighbor_weights, ppr_normalization)
+
+            if normalization == 'sym':
+                # We can change the normalization from row-normalized to symmetric
+                # by multiplying the resulting matrix
+                # with D^{1/2} from the left and D^{-1/2} from the right.
+                # Since we use the original degrees for this it will be like we had
+                # used symmetric normalization from the beginning
+                # (except for errors due to approximation).
+                diag_idx = torch.arange(0, num_nodes, dtype=torch.long,
+                                        device=edge_index.device)
+                diag_idx = diag_idx.unsqueeze(0).repeat(2, 1)
+
+                D_vec_sqrt = torch.sqrt(D_vec_orig)
+                edge_index, edge_weight = spspmm(diag_idx, D_vec_sqrt,
+                                                 edge_index, edge_weight,
+                                                 num_nodes, num_nodes, num_nodes)
+                D_vec_invsqrt = 1 / D_vec_sqrt
+                edge_index, edge_weight = spspmm(edge_index, edge_weight,
+                                                 diag_idx, D_vec_invsqrt,
+                                                 num_nodes, num_nodes, num_nodes)
+            else:
+                raise ValueError(f"Transition matrix normalization '{normalization}' unknown.")
+        elif method == 'heat':
+            raise NotImplementedError(
+                "Currently no fast heat kernel is implemented. "
+                "You are welcome to create one yourself, based on e.g. "
+                "Kloster and Gleich. Heat kernel based community detection. KDD 2014")
+        else:
+            raise ValueError(f"Approximate GDC diffusion '{method}' unknown.")
+        return edge_index, edge_weight
+
+    def _sparsify_dense(self, matrix, method, **kwargs):
+        """Sparsifies given dense matrix.
+
+        Args:
+            matrix (Tensor): Matrix to sparsify.
+            num_nodes (int): Number of nodes.
+            method (str): Method of sparsification. Options:
+                1. `"threshold"`: Remove all edges with weights smaller than `eps`.
+                Additionally expects one of these parameters:
+                - eps (float): Threshold to bound edges at.
+                - avg_degree (int): If `eps` is not given,
+                it can optionally be calculated by calculating
+                the `eps` required to achieve a given `avg_degree`.
+
+                2. `"topk"`: Keep edges with top `k` edge weights per node (column).
+                Additionally expects the following parameter:
+                - k (int): Specifies the number of edges to keep.
+
+        :rtype: (:class:`LongTensor`, :class:`Tensor`)
+        """
+        assert matrix.shape[0] == matrix.shape[1]
+        N = matrix.shape[1]
+        if method == 'threshold':
+            if 'eps' not in kwargs.keys():
+                kwargs['eps'] = self._calculate_eps(matrix, N, kwargs['avg_degree'])
+
+            edge_index = torch.nonzero(matrix >= kwargs['eps']).t()
+            edge_index_flat = edge_index[0] * N + edge_index[1]
+            edge_weight = matrix.flatten()[edge_index_flat]
+        elif method == 'topk':
+            sort_idx = torch.argsort(matrix, dim=0, descending=True)
+            top_idx = sort_idx[:kwargs['k']]
+
+            edge_weight = torch.gather(matrix, dim=0, index=top_idx).flatten()
+
+            source_idx = torch.arange(0, N).repeat(kwargs['k'])
+            edge_index = torch.stack([source_idx, top_idx.flatten()], dim=0)
+        else:
+            raise ValueError(f"GDC sparsification '{method}' unknown.")
+        return edge_index, edge_weight
+
+    def _sparsify_sparse(self, edge_index, edge_weight, num_nodes, method, **kwargs):
+        """Sparsifies given graph further.
+
+        Args:
+            edge_index (LongTensor): The edge indices.
+            edge_weight (Tensor): One-dimensional edge weights.
+            num_nodes (int): Number of nodes.
+            method (str): Method of sparsification. Options:
+                1. `"threshold"`: Remove all edges with weights smaller than `eps`.
+                Additionally expects one of these parameters:
+                - eps (float): Threshold to bound edges at.
+                - avg_degree (int): If `eps` is not given,
+                it can optionally be calculated by calculating
+                the `eps` required to achieve a given `avg_degree`.
+
+        :rtype: (:class:`LongTensor`, :class:`Tensor`)
+        """
+        if method == 'threshold':
+            if 'eps' not in kwargs.keys():
+                kwargs['eps'] = self._calculate_eps(edge_weight, num_nodes, kwargs['avg_degree'])
+
+            remaining_edge_idx = torch.nonzero(edge_weight >= kwargs['eps']).flatten()
+            edge_index = edge_index[:, remaining_edge_idx]
+            edge_weight = edge_weight[remaining_edge_idx]
+        elif method == 'topk':
+            raise NotImplementedError("Sparse topk sparsification not implemented.")
+        else:
+            raise ValueError(f"GDC sparsification '{method}' unknown.")
+        return edge_index, edge_weight
+
+    def _expm(self, matrix, symmetric):
+        """Calculate matrix exponential.
+
+        Args:
+            matrix (Tensor): Matrix to take exponential of.
+            symmetric (bool): Specifies whether the matrix is symmetric.
+
+        :rtype: (:class:`Tensor`)
+        """
+        if symmetric:
+            e, V = torch.symeig(matrix, eigenvectors=True)
+            diff_mat = V @ torch.diag(e.exp()) @ V.t()
+        else:
+            e, V = torch.eig(matrix, eigenvectors=True)
+            diff_mat = V @ torch.diag(e[:, 0].exp()) @ torch.inverse(V)
+        return diff_mat
+
+    def _calculate_eps(self, matrix, num_nodes, avg_degree):
+        """Calculate threshold necessary to achieve a given average degree.
+
+        Args:
+            matrix (Tensor): Adjacency matrix or edge weights.
+            num_nodes (int): Number of nodes.
+            avg_degree (int): Target average degree.
+
+        :rtype: (:class:`float`)
+        """
+        sorted_edges = torch.sort(matrix.flatten(), descending=True).values
+        if avg_degree * num_nodes > len(sorted_edges):
+            return -np.inf
+        return sorted_edges[avg_degree * num_nodes - 1]
+
+    def _neighbors_to_graph(self, neighbors, neighbor_weights, normalization='row'):
+        """Combine a list of neighbors and neighbor weights to create a sparse graph.
+
+        Args:
+            neighbors (List[List[int]]): List of neighbors for each node.
+            neighbor_weights (List[List[float]]): List of weights for the neighbors of each node.
+            normalization (str): Normalization of resulting matrix (options: `row`, `col`).
+
+        :rtype: (:class:`LongTensor`, :class:`Tensor`)
+        """
+        edge_weight = torch.Tensor(np.concatenate(neighbor_weights))
+        i = np.repeat(np.arange(len(neighbors)), np.fromiter(map(len, neighbors), dtype=np.int))
+        j = np.concatenate(neighbors)
+        if normalization == 'col':
+            edge_index = torch.Tensor(np.vstack([j, i]))
+            N = len(neighbors)
+            edge_index, edge_weight = coalesce(edge_index, edge_weight, N, N)
+        elif normalization == 'row':
+            edge_index = torch.Tensor(np.vstack([i, j]))
+        else:
+            raise ValueError(f"PPR matrix normalization {normalization} unknown.")
+        return edge_index, edge_weight
+
+    @staticmethod
+    @numba.njit(cache=True)
+    def _calc_ppr(indptr, indices, out_degree, alpha, eps):
+        """Calculate the personalized PageRank vector for all nodes
+        using a variant of the Andersen algorithm
+        (see Andersen et al. 2006. Local Graph Partitioning using PageRank Vectors.)
+
+        Args:
+            indptr (np.ndarray): Index pointer for the sparse matrix (CSR-format).
+            indices (np.ndarray): Indices of the sparse matrix entries (CSR-format).
+            out_degree (np.ndarray): Out-degree of each node.
+            alpha (float): Alpha of the PageRank to calculate.
+            eps (float): Threshold for PPR calculation stopping criterion
+                (`edge_weight` >= `eps` * `out_degree`).
+
+        :rtype: (:class:`List[List[int]]`, :class:`List[List[float]]`)
+        """
+        alpha_eps = alpha * eps
+        js = []
+        vals = []
+        for inode in range(len(out_degree)):
+            p = {inode: 0.0}
+            r = {}
+            r[inode] = alpha
+            q = [inode]
+            while len(q) > 0:
+                unode = q.pop()
+
+                res = r[unode] if unode in r else 0
+                if unode in p:
+                    p[unode] += res
+                else:
+                    p[unode] = res
+                r[unode] = 0
+                for vnode in indices[indptr[unode]:indptr[unode + 1]]:
+                    _val = (1 - alpha) * res / out_degree[unode]
+                    if vnode in r:
+                        r[vnode] += _val
+                    else:
+                        r[vnode] = _val
+
+                    res_vnode = r[vnode] if vnode in r else 0
+                    if res_vnode >= alpha_eps * out_degree[vnode]:
+                        if vnode not in q:
+                            q.append(vnode)
+            js.append(list(p.keys()))
+            vals.append(list(p.values()))
+        return js, vals
+
+    def __repr__(self):
+        return '{}()'.format(self.__class__.__name__)

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -1,5 +1,6 @@
 import numba
 import numpy as np
+from scipy.linalg import expm
 import torch
 from torch_geometric.utils import add_self_loops, is_undirected, to_dense_adj
 from torch_sparse import coalesce, spspmm
@@ -362,8 +363,8 @@ class GDC(object):
             e, V = torch.symeig(matrix, eigenvectors=True)
             diff_mat = V @ torch.diag(e.exp()) @ V.t()
         else:
-            e, V = torch.eig(matrix, eigenvectors=True)
-            diff_mat = V @ torch.diag(e[:, 0].exp()) @ torch.inverse(V)
+            diff_mat_np = expm(matrix.cpu().numpy())
+            diff_mat = torch.Tensor(diff_mat_np).to(matrix.device)
         return diff_mat
 
     def _calculate_eps(self, matrix, num_nodes, avg_degree):

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -1,7 +1,7 @@
+import torch
 import numba
 import numpy as np
 from scipy.linalg import expm
-import torch
 from torch_geometric.utils import add_self_loops, is_undirected, to_dense_adj
 from torch_sparse import coalesce, spspmm
 from torch_scatter import scatter_add
@@ -181,7 +181,7 @@ class GDC(object):
 
     def diffusion_matrix_exact(self, edge_index, edge_weight, num_nodes,
                                method, **kwargs):
-        """Calculate the (dense) diffusion on a given sparse graph.
+        r"""Calculate the (dense) diffusion on a given sparse graph.
         Note that these exact variants are not scalable. They densify the
         adjacency matrix and calculate either its inverse or its matrix
         exponential.
@@ -243,7 +243,7 @@ class GDC(object):
 
     def diffusion_matrix_approx(self, edge_index, edge_weight, num_nodes,
                                 normalization, method, **kwargs):
-        """Calculate the approximate, sparse diffusion on a given sparse graph.
+        r"""Calculate the approximate, sparse diffusion on a given sparse graph.
 
         Args:
             edge_index (LongTensor): The edge indices.
@@ -325,7 +325,7 @@ class GDC(object):
         return edge_index, edge_weight
 
     def sparsify_dense(self, matrix, method, **kwargs):
-        """Sparsifies the given dense matrix.
+        r"""Sparsifies the given dense matrix.
 
         Args:
             matrix (Tensor): Matrix to sparsify.
@@ -386,7 +386,7 @@ class GDC(object):
 
     def sparsify_sparse(self, edge_index, edge_weight, num_nodes, method,
                         **kwargs):
-        """Sparsifies a given sparse graph further.
+        r"""Sparsifies a given sparse graph further.
 
         Args:
             edge_index (LongTensor): The edge indices.
@@ -421,7 +421,7 @@ class GDC(object):
         return edge_index, edge_weight
 
     def __expm__(self, matrix, symmetric):
-        """Calculates matrix exponential.
+        r"""Calculates matrix exponential.
 
         Args:
             matrix (Tensor): Matrix to take exponential of.
@@ -438,7 +438,7 @@ class GDC(object):
         return diff_mat
 
     def __calculate_eps__(self, matrix, num_nodes, avg_degree):
-        """Calculates threshold necessary to achieve a given average degree.
+        r"""Calculates threshold necessary to achieve a given average degree.
 
         Args:
             matrix (Tensor): Adjacency matrix or edge weights.
@@ -454,7 +454,7 @@ class GDC(object):
 
     def __neighbors_to_graph__(self, neighbors, neighbor_weights,
                                normalization='row', device='cpu'):
-        """Combine a list of neighbors and neighbor weights to create a sparse
+        r"""Combine a list of neighbors and neighbor weights to create a sparse
         graph.
 
         Args:
@@ -486,7 +486,7 @@ class GDC(object):
     @staticmethod
     @numba.njit(cache=True)
     def __calc_ppr__(indptr, indices, out_degree, alpha, eps):
-        """Calculate the personalized PageRank vector for all nodes
+        r"""Calculate the personalized PageRank vector for all nodes
         using a variant of the Andersen algorithm
         (see Andersen et al. :Local Graph Partitioning using PageRank Vectors.)
 

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -8,50 +8,64 @@ from torch_scatter import scatter_add
 
 
 class GDC(object):
-    r"""Preprocesses the graph via Graph Diffusion Convolution (GDC).
+    r"""Processes the graph via Graph Diffusion Convolution (GDC) from the
+    `"Diffusion Improves Graph Learning" <https://www.kdd.in.tum.de/gdc>`_
+    paper.
 
-    As proposed in `"Diffusion Improves Graph Learning"
-    <https://www.kdd.in.tum.de/gdc>`_.
-    Johannes Klicpera, Stefan Weißenberger, Stephan Günnemann
-    NeurIPS 2019
+    .. note::
 
-    The paper offers additional advice on how to choose the hyperparameters.
-    For an example of using GCN with GDC, see :source:`examples/gcn.py`.
+        The paper offers additional advice on how to choose the
+        hyperparameters.
+        For an example of using GCN with GDC, see `:source:`examples/gcn.py`
+        <https://github.com/rusty1s/pytorch_geometric/blob/master/examples/
+        gcn.py>`_.
 
     Args:
         self_loop_weight (float, optional): Weight of the added self-loop.
             Set to :obj:`None` to add no self-loops. (default: :obj:`1`)
-        normalization_in (str, optional): Normalization of the transition matrix
-            on the original (input) graph. Possible values: `"sym"`, `"col"`, and `"row"`.
-            See :func:`GDC._transition_matrix` for details. (default: :obj:`"sym"`)
-        normalization_out (str, optional): Normalization of the transition matrix
-            on the transformed GDC (output) graph. Possible values: `"sym"`, `"col"`, `"row"`, and `None`.
-            See :func:`GDC._transition_matrix` for details. (default: :obj:`"col"`)
-        diffusion_kwargs (dict, optional): Dictionary containing the parameters for diffusion.
-            `method` specifies the diffusion method (values: `"ppr"`, `"heat"`, `"coeff"`).
+        normalization_in (str, optional): Normalization of the transition
+            matrix on the original (input) graph. Possible values:
+            `"sym"`, `"col"`, and `"row"`.
+            See :func:`GDC.transition_matrix` for details.
+            (default: :obj:`"sym"`)
+        normalization_out (str, optional): Normalization of the transition
+            matrix on the transformed GDC (output) graph. Possible values:
+            `"sym"`, `"col"`, `"row"`, and `None`.
+            See :func:`GDC.transition_matrix` for details.
+            (default: :obj:`"col"`)
+        diffusion_kwargs (dict, optional): Dictionary containing the parameters
+            for diffusion.
+            `method` specifies the diffusion method (`"ppr"`, `"heat"` or
+            `"coeff"`).
             Each diffusion method requires different additional parameters.
-            See :func:`GDC._diffusion_matrix_exact` or :func:`GDC._diffusion_matrix_approx` for details.
+            See :func:`GDC.diffusion_matrix_exact` or
+            :func:`GDC.diffusion_matrix_approx` for details.
             (default: :obj:`dict(method='ppr', alpha=0.15)`)
-        sparsification_kwargs (dict, optional): Dictionary containing the parameters for sparsification.
-            `method` specifies the sparsification method (values: `threshold`, `topk`).
-            Each sparsification method requires different additional parameters.
-            See :func:`GDC._sparsify_dense` for details.
+        sparsification_kwargs (dict, optional): Dictionary containing the
+            parameters for sparsification.
+            `method` specifies the sparsification method (`threshold` or
+            `topk`).
+            Each sparsification method requires different additional
+            parameters.
+            See :func:`GDC.sparsify_dense` for details.
             (default: :obj:`dict(method='threshold', avg_degree=64)`)
-        exact (bool, optional): Whether to exactly calculate the diffusion matrix.
-            Note that the exact variants are not scalable. They densify the adjacency matrix
-            and calculate either its inverse or its matrix exponential.
-            However, the approximate variants do not support edge weights
-            and currently only personalized PageRank and sparsification by threshold
-            are implemented as fast, approximate versions. (default: :obj:`True`)
+        exact (bool, optional): Whether to exactly calculate the diffusion
+            matrix.
+            Note that the exact variants are not scalable.
+            They densify the adjacency matrix and calculate either its inverse
+            or its matrix exponential.
+            However, the approximate variants do not support edge weights and
+            currently only personalized PageRank and sparsification by
+            threshold are implemented as fast, approximate versions.
+            (default: :obj:`True`)
 
     :rtype: :class:`torch_geometric.data.Data`
     """
-
-    def __init__(self, self_loop_weight=1,
-                 normalization_in='sym', normalization_out='col',
+    def __init__(self, self_loop_weight=1, normalization_in='sym',
+                 normalization_out='col',
                  diffusion_kwargs=dict(method='ppr', alpha=0.15),
-                 sparsification_kwargs=dict(method='threshold', avg_degree=64),
-                 exact=True):
+                 sparsification_kwargs=dict(method='threshold',
+                                            avg_degree=64), exact=True):
         self.self_loop_weight = self_loop_weight
         self.normalization_in = normalization_in
         self.normalization_out = normalization_out
@@ -67,38 +81,47 @@ class GDC(object):
         N = data.num_nodes
         edge_index = data.edge_index
         if data.edge_attr is None:
-            edge_weight = torch.ones(edge_index.size(1), device=edge_index.device)
+            edge_weight = torch.ones(edge_index.size(1),
+                                     device=edge_index.device)
         else:
             edge_weight = data.edge_attr
             assert self.exact
             assert edge_weight.dim() == 1
 
         if self.self_loop_weight:
-            edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
-                                                     fill_value=self.self_loop_weight,
-                                                     num_nodes=N)
+            edge_index, edge_weight = add_self_loops(
+                edge_index, edge_weight, fill_value=self.self_loop_weight,
+                num_nodes=N)
 
         edge_index, edge_weight = coalesce(edge_index, edge_weight, N, N)
 
         if self.exact:
-            edge_index, edge_weight = self._transition_matrix(edge_index, edge_weight, N, self.normalization_in)
-            diff_mat = self._diffusion_matrix_exact(edge_index, edge_weight, N, **self.diffusion_kwargs)
-            edge_index, edge_weight = self._sparsify_dense(diff_mat, **self.sparsification_kwargs)
+            edge_index, edge_weight = self.transition_matrix(
+                edge_index, edge_weight, N, self.normalization_in)
+            diff_mat = self.diffusion_matrix_exact(edge_index, edge_weight, N,
+                                                   **self.diffusion_kwargs)
+            edge_index, edge_weight = self.sparsify_dense(
+                diff_mat, **self.sparsification_kwargs)
         else:
-            edge_index, edge_weight = self._diffusion_matrix_approx(edge_index, edge_weight, N,
-                                                                    self.normalization_in, **self.diffusion_kwargs)
-            edge_index, edge_weight = self._sparsify_sparse(edge_index, edge_weight, N, **self.sparsification_kwargs)
+            edge_index, edge_weight = self.diffusion_matrix_approx(
+                edge_index, edge_weight, N, self.normalization_in,
+                **self.diffusion_kwargs)
+            edge_index, edge_weight = self.sparsify_sparse(
+                edge_index, edge_weight, N, **self.sparsification_kwargs)
 
         edge_index, edge_weight = coalesce(edge_index, edge_weight, N, N)
-        edge_index, edge_weight = self._transition_matrix(edge_index, edge_weight, N, self.normalization_out)
+        edge_index, edge_weight = self.transition_matrix(
+            edge_index, edge_weight, N, self.normalization_out)
 
         data.edge_index = edge_index
         data.edge_attr = edge_weight
 
         return data
 
-    def _transition_matrix(self, edge_index, edge_weight, num_nodes, normalization):
-        r"""Calculate the approximate, sparse diffusion on a given sparse matrix.
+    def transition_matrix(self, edge_index, edge_weight, num_nodes,
+                          normalization):
+        r"""Calculate the approximate, sparse diffusion on a given sparse
+        matrix.
 
         Args:
             edge_index (LongTensor): The edge indices.
@@ -130,82 +153,83 @@ class GDC(object):
             edge_index, edge_weight = spspmm(diag_idx, D_vec_invsqrt,
                                              edge_index, edge_weight,
                                              num_nodes, num_nodes, num_nodes)
-            edge_index, edge_weight = spspmm(edge_index, edge_weight,
-                                             diag_idx, D_vec_invsqrt,
-                                             num_nodes, num_nodes, num_nodes)
+            edge_index, edge_weight = spspmm(edge_index, edge_weight, diag_idx,
+                                             D_vec_invsqrt, num_nodes,
+                                             num_nodes, num_nodes)
         elif normalization == 'col':
             _, col = edge_index
             D_vec = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
             D_vec_inv = 1 / D_vec
-            edge_index, edge_weight = spspmm(edge_index, edge_weight,
-                                             diag_idx, D_vec_inv,
-                                             num_nodes, num_nodes, num_nodes)
+            edge_index, edge_weight = spspmm(edge_index, edge_weight, diag_idx,
+                                             D_vec_inv, num_nodes, num_nodes,
+                                             num_nodes)
         elif normalization == 'row':
             row, _ = edge_index
             D_vec = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
             D_vec_inv = 1 / D_vec
-            edge_index, edge_weight = spspmm(diag_idx, D_vec_inv,
-                                             edge_index, edge_weight,
-                                             num_nodes, num_nodes, num_nodes)
+            edge_index, edge_weight = spspmm(diag_idx, D_vec_inv, edge_index,
+                                             edge_weight, num_nodes, num_nodes,
+                                             num_nodes)
         elif normalization is None:
             pass
         else:
-            raise ValueError(f"Transition matrix normalization '{normalization}' unknown.")
+            raise ValueError(
+                'Transition matrix normalization {} unknown.'.format(
+                    normalization))
+
         return edge_index, edge_weight
 
-    def _diffusion_matrix_exact(self, edge_index, edge_weight, num_nodes, method, **kwargs):
+    def diffusion_matrix_exact(self, edge_index, edge_weight, num_nodes,
+                               method, **kwargs):
         """Calculate the (dense) diffusion on a given sparse graph.
-        Note that these exact variants are not scalable. They densify the adjacency matrix
-        and calculate either its inverse or its matrix exponential.
+        Note that these exact variants are not scalable. They densify the
+        adjacency matrix and calculate either its inverse or its matrix
+        exponential.
 
         Args:
             edge_index (LongTensor): The edge indices.
             edge_weight (Tensor): One-dimensional edge weights.
             num_nodes (int): Number of nodes.
             method (str): Diffusion method. Options:
-                1. `"ppr"`: Use personalized PageRank as diffusion.
+                1. :obj:`"ppr"`: Use personalized PageRank as diffusion.
                 Additionally expects the parameter:
-                - alpha (float): Return probability in PPR. Commonly lies in [0.05, 0.2].
+                - alpha (float): Return probability in PPR. Commonly lies in
+                    :obj:`[0.05, 0.2]`.
 
                 2. `"heat"`: Use heat kernel diffusion.
                 Additionally expects the parameter:
-                - t (float): Time of diffusion. Commonly lies in [2, 10].
+                - :obj:`t` (float): Time of diffusion. Commonly lies in
+                    :obj:`[2, 10]`.
 
-                3. `"coeff"`: Freely choose diffusion coefficients.
+                3. :obj:`"coeff"`: Freely choose diffusion coefficients.
                 Additionally expects the parameter:
-                - coeffs (List[float]): List of coefficients theta_k
-                for each power of the transition matrix (starting at 0).
+                - coeffs (List[float]): List of coefficients :obj:`theta_k`
+                for each power of the transition matrix (starting at :obj:`0`).
 
         :rtype: (:class:`Tensor`)
         """
         if method == 'ppr':
             # α (I_n + (α - 1) A)^-1
-
             edge_weight = (kwargs['alpha'] - 1) * edge_weight
             edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
                                                      fill_value=1,
                                                      num_nodes=num_nodes)
-
-            # Densify matrix
             mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
-
             diff_matrix = kwargs['alpha'] * torch.inverse(mat)
+
         elif method == 'heat':
             # exp(t (A - I_n))
-
             edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
                                                      fill_value=-1,
                                                      num_nodes=num_nodes)
             edge_weight = kwargs['t'] * edge_weight
-
-            # Densify matrix
             mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
-
             undirected = is_undirected(edge_index, edge_weight, num_nodes)
-            diff_matrix = self._expm(mat, undirected)
+            diff_matrix = self.__expm__(mat, undirected)
+
         elif method == 'coeff':
-            # Densify matrix
-            adj_matrix = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
+            adj_matrix = to_dense_adj(edge_index,
+                                      edge_attr=edge_weight).squeeze()
             mat = torch.eye(num_nodes, device=edge_index.device)
 
             diff_matrix = kwargs['coeffs'][0] * mat
@@ -213,49 +237,59 @@ class GDC(object):
                 mat = mat @ adj_matrix
                 diff_matrix += coeff * mat
         else:
-            raise ValueError(f"Exact GDC diffusion '{method}' unknown.")
+            raise ValueError('Exact GDC diffusion {} unknown.'.format(method))
+
         return diff_matrix
 
-    def _diffusion_matrix_approx(self, edge_index, edge_weight, num_nodes, normalization, method, **kwargs):
+    def diffusion_matrix_approx(self, edge_index, edge_weight, num_nodes,
+                                normalization, method, **kwargs):
         """Calculate the approximate, sparse diffusion on a given sparse graph.
 
         Args:
             edge_index (LongTensor): The edge indices.
             edge_weight (Tensor): One-dimensional edge weights.
             num_nodes (int): Number of nodes.
-            normalization (str): Transition matrix normalization scheme (`"sym"`, `"row"`, or `"col"`).
-                See :func:`GDC._transition_matrix` for details.
+            normalization (str): Transition matrix normalization scheme
+                (`"sym"`, `"row"`, or `"col"`).
+                See :func:`GDC.transition_matrix` for details.
             method (str): Diffusion method. Options:
                 1. `"ppr"`: Use personalized PageRank as diffusion.
                 Additionally expects the parameters:
-                - alpha (float): Return probability in PPR. Commonly lies in [0.05, 0.2].
+                - alpha (float): Return probability in PPR. Commonly lies in
+                    :obj:`[0.05, 0.2]`.
                 - eps (float): Threshold for PPR calculation stopping criterion
-                (`edge_weight` >= `eps` * `out_degree`). Recommended default: `1e-4`.
+                    (:obj:`edge_weight >= eps * out_degree`).
+                    Recommended default: :obj:`1e-4`.
 
         :rtype: (:class:`LongTensor`, :class:`Tensor`)
         """
         if method == 'ppr':
             if normalization == 'sym':
-                # Calculate original degrees
+                # Calculate original degrees.
                 _, col = edge_index
-                D_vec_orig = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
+                D_vec_orig = scatter_add(edge_weight, col, dim=0,
+                                         dim_size=num_nodes)
 
             edge_index_np = edge_index.cpu().numpy()
-            # Assumes coalesced edge_index
-            _, indptr, out_degree = np.unique(edge_index_np[0], return_index=True, return_counts=True)
+            # Assumes coalesced edge_index.
+            _, indptr, out_degree = np.unique(edge_index_np[0],
+                                              return_index=True,
+                                              return_counts=True)
 
-            neighbors, neighbor_weights = GDC._calc_ppr(indptr, edge_index_np[1], out_degree,
-                                                        kwargs['alpha'], kwargs['eps'])
+            neighbors, neighbor_weights = GDC.__calc_ppr__(
+                indptr, edge_index_np[1], out_degree, kwargs['alpha'],
+                kwargs['eps'])
             ppr_normalization = 'col' if normalization == 'col' else 'row'
-            edge_index, edge_weight = self._neighbors_to_graph(neighbors, neighbor_weights,
-                                                               ppr_normalization, device=edge_index.device)
+            edge_index, edge_weight = self.__neighbors_to_graph__(
+                neighbors, neighbor_weights, ppr_normalization,
+                device=edge_index.device)
 
             if normalization == 'sym':
-                # We can change the normalization from row-normalized to symmetric
-                # by multiplying the resulting matrix
-                # with D^{1/2} from the left and D^{-1/2} from the right.
-                # Since we use the original degrees for this it will be like we had
-                # used symmetric normalization from the beginning
+                # We can change the normalization from row-normalized to
+                # symmetric by multiplying the resulting matrix with D^{1/2}
+                # from the left and D^{-1/2} from the right.
+                # Since we use the original degrees for this it will be like
+                # we had used symmetric normalization from the beginning
                 # (except for errors due to approximation).
                 diag_idx = torch.arange(0, num_nodes, dtype=torch.long,
                                         device=edge_index.device)
@@ -264,83 +298,103 @@ class GDC(object):
                 D_vec_sqrt = torch.sqrt(D_vec_orig)
                 edge_index, edge_weight = spspmm(diag_idx, D_vec_sqrt,
                                                  edge_index, edge_weight,
-                                                 num_nodes, num_nodes, num_nodes)
+                                                 num_nodes, num_nodes,
+                                                 num_nodes)
                 D_vec_invsqrt = 1 / D_vec_sqrt
                 edge_index, edge_weight = spspmm(edge_index, edge_weight,
                                                  diag_idx, D_vec_invsqrt,
-                                                 num_nodes, num_nodes, num_nodes)
+                                                 num_nodes, num_nodes,
+                                                 num_nodes)
             elif normalization in ['col', 'row']:
                 pass
             else:
-                raise ValueError(f"Transition matrix normalization '{normalization}'"
-                                 f" not implemented for non-exact GDC computation.")
+                raise ValueError(
+                    ('Transition matrix normalization {} not implemented for '
+                     'non-exact GDC computation.').format(normalization))
+
         elif method == 'heat':
             raise NotImplementedError(
-                "Currently no fast heat kernel is implemented. "
-                "You are welcome to create one yourself, based on e.g. "
-                "Kloster and Gleich. Heat kernel based community detection. KDD 2014")
+                ('Currently no fast heat kernel is implemented. You are '
+                 'welcome to create one yourself, e.g., based on '
+                 '"Kloster and Gleich: Heat kernel based community detection '
+                 '(KDD 2014)."'))
         else:
-            raise ValueError(f"Approximate GDC diffusion '{method}' unknown.")
+            raise ValueError(
+                'Approximate GDC diffusion {} unknown.'.format(method))
+
         return edge_index, edge_weight
 
-    def _sparsify_dense(self, matrix, method, **kwargs):
-        """Sparsifies given dense matrix.
+    def sparsify_dense(self, matrix, method, **kwargs):
+        """Sparsifies the given dense matrix.
 
         Args:
             matrix (Tensor): Matrix to sparsify.
             num_nodes (int): Number of nodes.
             method (str): Method of sparsification. Options:
-                1. `"threshold"`: Remove all edges with weights smaller than `eps`.
-                Additionally expects one of these parameters:
+                1. :obj:`"threshold"`: Remove all edges with weights smaller
+                    than :obj:`eps`.
+                    Additionally expects one of these parameters:
                 - eps (float): Threshold to bound edges at.
                 - avg_degree (int): If `eps` is not given,
                 it can optionally be calculated by calculating
                 the `eps` required to achieve a given `avg_degree`.
 
-                2. `"topk"`: Keep edges with top `k` edge weights per node (column).
-                Additionally expects the following parameters:
-                - k (int): Specifies the number of edges to keep.
-                - dim (int): The axis along which to take the top k.
+                2. `"topk"`: Keep edges with top `k` edge weights per node
+                    (column).
+                    Additionally expects the following parameters:
+                    - k (int): Specifies the number of edges to keep.
+                    - dim (int): The axis along which to take the top k.
 
         :rtype: (:class:`LongTensor`, :class:`Tensor`)
         """
         assert matrix.shape[0] == matrix.shape[1]
         N = matrix.shape[1]
+
         if method == 'threshold':
             if 'eps' not in kwargs.keys():
-                kwargs['eps'] = self._calculate_eps(matrix, N, kwargs['avg_degree'])
+                kwargs['eps'] = self.__calculate_eps__(matrix, N,
+                                                       kwargs['avg_degree'])
 
             edge_index = torch.nonzero(matrix >= kwargs['eps']).t()
             edge_index_flat = edge_index[0] * N + edge_index[1]
             edge_weight = matrix.flatten()[edge_index_flat]
+
         elif method == 'topk':
             assert kwargs['dim'] in [0, 1]
-            sort_idx = torch.argsort(matrix, dim=kwargs['dim'], descending=True)
+            sort_idx = torch.argsort(matrix, dim=kwargs['dim'],
+                                     descending=True)
             if kwargs['dim'] == 0:
                 top_idx = sort_idx[:kwargs['k']]
-                edge_weight = torch.gather(matrix, dim=kwargs['dim'], index=top_idx).flatten()
+                edge_weight = torch.gather(matrix, dim=kwargs['dim'],
+                                           index=top_idx).flatten()
 
-                row_idx = torch.arange(0, N, device=matrix.device).repeat(kwargs['k'])
+                row_idx = torch.arange(0, N, device=matrix.device).repeat(
+                    kwargs['k'])
                 edge_index = torch.stack([top_idx.flatten(), row_idx], dim=0)
             else:
                 top_idx = sort_idx[:, :kwargs['k']]
-                edge_weight = torch.gather(matrix, dim=kwargs['dim'], index=top_idx).flatten()
+                edge_weight = torch.gather(matrix, dim=kwargs['dim'],
+                                           index=top_idx).flatten()
 
-                col_idx = torch.arange(0, N, device=matrix.device).repeat_interleave(kwargs['k'])
+                col_idx = torch.arange(
+                    0, N, device=matrix.device).repeat_interleave(kwargs['k'])
                 edge_index = torch.stack([col_idx, top_idx.flatten()], dim=0)
         else:
-            raise ValueError(f"GDC sparsification '{method}' unknown.")
+            raise ValueError('GDC sparsification {} unknown.'.format(method))
+
         return edge_index, edge_weight
 
-    def _sparsify_sparse(self, edge_index, edge_weight, num_nodes, method, **kwargs):
-        """Sparsifies given graph further.
+    def sparsify_sparse(self, edge_index, edge_weight, num_nodes, method,
+                        **kwargs):
+        """Sparsifies a given sparse graph further.
 
         Args:
             edge_index (LongTensor): The edge indices.
             edge_weight (Tensor): One-dimensional edge weights.
             num_nodes (int): Number of nodes.
             method (str): Method of sparsification. Options:
-                1. `"threshold"`: Remove all edges with weights smaller than `eps`.
+                1. `"threshold"`: Remove all edges with weights smaller than
+                :obj:`eps`.
                 Additionally expects one of these parameters:
                 - eps (float): Threshold to bound edges at.
                 - avg_degree (int): If `eps` is not given,
@@ -351,19 +405,23 @@ class GDC(object):
         """
         if method == 'threshold':
             if 'eps' not in kwargs.keys():
-                kwargs['eps'] = self._calculate_eps(edge_weight, num_nodes, kwargs['avg_degree'])
+                kwargs['eps'] = self.__calculate_eps__(edge_weight, num_nodes,
+                                                       kwargs['avg_degree'])
 
-            remaining_edge_idx = torch.nonzero(edge_weight >= kwargs['eps']).flatten()
+            remaining_edge_idx = torch.nonzero(
+                edge_weight >= kwargs['eps']).flatten()
             edge_index = edge_index[:, remaining_edge_idx]
             edge_weight = edge_weight[remaining_edge_idx]
         elif method == 'topk':
-            raise NotImplementedError("Sparse topk sparsification not implemented.")
+            raise NotImplementedError(
+                'Sparse topk sparsification not implemented.')
         else:
-            raise ValueError(f"GDC sparsification '{method}' unknown.")
+            raise ValueError('GDC sparsification {} unknown.'.format(method))
+
         return edge_index, edge_weight
 
-    def _expm(self, matrix, symmetric):
-        """Calculate matrix exponential.
+    def __expm__(self, matrix, symmetric):
+        """Calculates matrix exponential.
 
         Args:
             matrix (Tensor): Matrix to take exponential of.
@@ -379,8 +437,8 @@ class GDC(object):
             diff_mat = torch.Tensor(diff_mat_np).to(matrix.device)
         return diff_mat
 
-    def _calculate_eps(self, matrix, num_nodes, avg_degree):
-        """Calculate threshold necessary to achieve a given average degree.
+    def __calculate_eps__(self, matrix, num_nodes, avg_degree):
+        """Calculates threshold necessary to achieve a given average degree.
 
         Args:
             matrix (Tensor): Adjacency matrix or edge weights.
@@ -394,19 +452,25 @@ class GDC(object):
             return -np.inf
         return sorted_edges[avg_degree * num_nodes - 1]
 
-    def _neighbors_to_graph(self, neighbors, neighbor_weights, normalization='row', device='cpu'):
-        """Combine a list of neighbors and neighbor weights to create a sparse graph.
+    def __neighbors_to_graph__(self, neighbors, neighbor_weights,
+                               normalization='row', device='cpu'):
+        """Combine a list of neighbors and neighbor weights to create a sparse
+        graph.
 
         Args:
             neighbors (List[List[int]]): List of neighbors for each node.
-            neighbor_weights (List[List[float]]): List of weights for the neighbors of each node.
-            normalization (str): Normalization of resulting matrix (options: `row`, `col`).
+            neighbor_weights (List[List[float]]): List of weights for the
+                neighbors of each node.
+            normalization (str): Normalization of resulting matrix
+                (options: `row`, `col`). (default: :obj:`"row"`)
             device (torch.device): Device to create output tensors on.
+                (default: :obj:`"cpu"`)
 
         :rtype: (:class:`LongTensor`, :class:`Tensor`)
         """
         edge_weight = torch.Tensor(np.concatenate(neighbor_weights)).to(device)
-        i = np.repeat(np.arange(len(neighbors)), np.fromiter(map(len, neighbors), dtype=np.int))
+        i = np.repeat(np.arange(len(neighbors)),
+                      np.fromiter(map(len, neighbors), dtype=np.int))
         j = np.concatenate(neighbors)
         if normalization == 'col':
             edge_index = torch.Tensor(np.vstack([j, i])).to(device)
@@ -415,23 +479,26 @@ class GDC(object):
         elif normalization == 'row':
             edge_index = torch.Tensor(np.vstack([i, j])).to(device)
         else:
-            raise ValueError(f"PPR matrix normalization {normalization} unknown.")
+            raise ValueError(
+                f"PPR matrix normalization {normalization} unknown.")
         return edge_index, edge_weight
 
     @staticmethod
     @numba.njit(cache=True)
-    def _calc_ppr(indptr, indices, out_degree, alpha, eps):
+    def __calc_ppr__(indptr, indices, out_degree, alpha, eps):
         """Calculate the personalized PageRank vector for all nodes
         using a variant of the Andersen algorithm
-        (see Andersen et al. 2006. Local Graph Partitioning using PageRank Vectors.)
+        (see Andersen et al. :Local Graph Partitioning using PageRank Vectors.)
 
         Args:
-            indptr (np.ndarray): Index pointer for the sparse matrix (CSR-format).
-            indices (np.ndarray): Indices of the sparse matrix entries (CSR-format).
+            indptr (np.ndarray): Index pointer for the sparse matrix
+                (CSR-format).
+            indices (np.ndarray): Indices of the sparse matrix entries
+                (CSR-format).
             out_degree (np.ndarray): Out-degree of each node.
             alpha (float): Alpha of the PageRank to calculate.
             eps (float): Threshold for PPR calculation stopping criterion
-                (`edge_weight` >= `eps` * `out_degree`).
+                (:obj:`edge_weight >= eps * out_degree`).
 
         :rtype: (:class:`List[List[int]]`, :class:`List[List[float]]`)
         """

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -26,7 +26,7 @@ class GDC(object):
             `method` specifies the diffusion method (values: `"ppr"`, `"heat"`, `"coeff"`).
             Each diffusion method requires different additional parameters.
             See :func:`GDC._diffusion_matrix_exact` or :func:`GDC._diffusion_matrix_approx` for details.
-            (default: :obj:`dict(method='ppr', alpha=0.15, eps=1e-4)`)
+            (default: :obj:`dict(method='ppr', alpha=0.15)`)
         sparsification_kwargs (dict, optional): Dictionary containing the parameters for sparsification.
             `method` specifies the sparsification method (values: `threshold`, `topk`).
             Each sparsification method requires different additional parameters.
@@ -37,16 +37,16 @@ class GDC(object):
             and calculate either its inverse or its matrix exponential.
             However, the approximate variants do not support edge weights
             and currently only personalized PageRank and sparsification by threshold
-            are implemented as fast, approximate versions. (default: :obj:`False`)
+            are implemented as fast, approximate versions. (default: :obj:`True`)
 
     :rtype: :class:`torch_geometric.data.Data`
     """
 
     def __init__(self, self_loop_weight=1,
                  normalization_in='sym', normalization_out='col',
-                 diffusion_kwargs=dict(method='ppr', alpha=0.15, eps=1e-4),
+                 diffusion_kwargs=dict(method='ppr', alpha=0.15),
                  sparsification_kwargs=dict(method='threshold', avg_degree=64),
-                 exact=False):
+                 exact=True):
         self.self_loop_weight = self_loop_weight
         self.normalization_in = normalization_in
         self.normalization_out = normalization_out
@@ -225,7 +225,7 @@ class GDC(object):
                 Additionally expects the parameters:
                 - alpha (float): Return probability in PPR. Commonly lies in [0.05, 0.2].
                 - eps (float): Threshold for PPR calculation stopping criterion
-                (`edge_weight` >= `eps` * `out_degree`).
+                (`edge_weight` >= `eps` * `out_degree`). Recommended default: `1e-4`.
 
         :rtype: (:class:`LongTensor`, :class:`Tensor`)
         """

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -10,9 +10,13 @@ from torch_scatter import scatter_add
 class GDC(object):
     r"""Preprocesses the graph via Graph Diffusion Convolution (GDC).
 
-    As proposed in Diffusion Improves Graph Learning.
+    As proposed in `"Diffusion Improves Graph Learning"
+    <https://arxiv.org/abs/1911.05485>`_.
     Johannes Klicpera, Stefan Weißenberger, Stephan Günnemann
     NeurIPS 2019, see www.kdd.in.tum.de/gdc
+
+    The paper offers additional advice on how to choose the hyperparameters.
+    For an example of using GCN with GDC, see :source:`examples/gcn.py`.
 
     Args:
         self_loop_weight (float, optional): Weight of the added self-loop.

--- a/torch_geometric/utils/undirected.py
+++ b/torch_geometric/utils/undirected.py
@@ -18,18 +18,18 @@ def is_undirected(edge_index, edge_attr=None, num_nodes=None):
     :rtype: bool
     """
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
-    edge_index, edge_attr = coalesce(edge_index, edge_attr, num_nodes, num_nodes)
+    edge_index, edge_attr = coalesce(edge_index, edge_attr, num_nodes,
+                                     num_nodes)
 
     if edge_attr is None:
         undirected_edge_index = to_undirected(edge_index, num_nodes=num_nodes)
         return edge_index.size(1) == undirected_edge_index.size(1)
     else:
-        assert edge_attr.dim() == 1
-        edge_index_t, edge_attr_t = transpose(edge_index, edge_attr,
-                                              num_nodes, num_nodes, coalesced=True)
+        edge_index_t, edge_attr_t = transpose(edge_index, edge_attr, num_nodes,
+                                              num_nodes, coalesced=True)
         index_symmetric = torch.all(edge_index == edge_index_t)
         attr_symmetric = torch.all(edge_attr == edge_attr_t)
-        return True if (index_symmetric and attr_symmetric) else False
+        return index_symmetric and attr_symmetric
 
 
 def to_undirected(edge_index, num_nodes=None):

--- a/torch_geometric/utils/undirected.py
+++ b/torch_geometric/utils/undirected.py
@@ -1,24 +1,35 @@
 import torch
-from torch_sparse import coalesce
+from torch_sparse import coalesce, transpose
 
 from .num_nodes import maybe_num_nodes
 
 
-def is_undirected(edge_index, num_nodes=None):
+def is_undirected(edge_index, edge_attr=None, num_nodes=None):
     r"""Returns :obj:`True` if the graph given by :attr:`edge_index` is
     undirected.
 
     Args:
         edge_index (LongTensor): The edge indices.
+        edge_attr (Tensor, optional): Edge weights or multi-dimensional
+            edge features. (default: :obj:`None`)
         num_nodes (int, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
 
     :rtype: bool
     """
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
-    edge_index, _ = coalesce(edge_index, None, num_nodes, num_nodes)
-    undirected_edge_index = to_undirected(edge_index, num_nodes=num_nodes)
-    return edge_index.size(1) == undirected_edge_index.size(1)
+    edge_index, edge_attr = coalesce(edge_index, edge_attr, num_nodes, num_nodes)
+
+    if edge_attr is None:
+        undirected_edge_index = to_undirected(edge_index, num_nodes=num_nodes)
+        return edge_index.size(1) == undirected_edge_index.size(1)
+    else:
+        assert edge_attr.dim() == 1
+        edge_index_t, edge_attr_t = transpose(edge_index, edge_attr,
+                                              num_nodes, num_nodes, coalesced=True)
+        index_symmetric = torch.all(edge_index == edge_index_t)
+        attr_symmetric = torch.all(edge_attr == edge_attr_t)
+        return True if (index_symmetric and attr_symmetric) else False
 
 
 def to_undirected(edge_index, num_nodes=None):


### PR DESCRIPTION
This PR implements the full pipeline used by Graph Diffusion Convolution (GDC) from "Diffusion Improves Graph Learning" (NeurIPS 2019) as a preprocessing step (data transformation).

GDC is monolithically implemented in a single class. Not sure if it would be smarter to split up the separate steps and then just call them in a wrapping GDC function. But I think this is a good (and complete) start.

I've also added a fast and scalable implementation of PPR for this. This implementation requires Numba, so I've added Numba to the required packages. I'm open to better ways of handling this.