### PR TITLE
'add grid_sampling for pointcloud'

### DIFF
--- a/test/transforms/test_grid_sampling.py
+++ b/test/transforms/test_grid_sampling.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 import torch
 from torch_geometric.transforms import GridSampling
 from torch_geometric.data import Data
@@ -15,9 +16,13 @@ def test_grid_sampling():
     batch = torch.from_numpy(np.zeros(num_points)).long()
     
     y = np.asarray(np.random.randint(0, num_classes, 5))
-    uniq = np.unique(y)
+    uniq, counts = np.unique(y, return_counts=True)
+    answer = uniq[np.argmax(counts)]
+    
     y = torch.from_numpy(y)
 
     out_data = GridSampling(0.04, 2)()(Data(pos=pos, batch=batch, y=y))
 
-    assert out_data.y == uniq[0]
+    out_y = out_data.y.detach().cpu().numpy()
+
+    npt.assert_array_almost_equal(answer, out_y)

--- a/test/transforms/test_grid_sampling.py
+++ b/test/transforms/test_grid_sampling.py
@@ -1,0 +1,23 @@
+import numpy as np
+import torch
+from torch_geometric.transforms import GridSampling
+from torch_geometric.data import Data
+
+
+def test_grid_sampling():
+    assert GridSampling(0.01, 12).__repr__() == 'GridSampling(0.01, 12)'
+
+    num_points = 5
+    num_classes = 2
+
+    pos = torch.Tensor([[0, 0, 0.01], [0.01, 0, 0], [0, 0.01, 0], [0, 0.01, 0], [0.01, 0, 0.01]])
+    
+    batch = torch.from_numpy(np.zeros(num_points)).long()
+    
+    y = np.asarray(np.random.randint(0, num_classes, 5))
+    uniq = np.unique(y)
+    y = torch.from_numpy(y)
+
+    out_data = GridSampling(0.04, 2)()(Data(pos=pos, batch=batch, y=y))
+
+    assert out_data.y == uniq[0]

--- a/test/transforms/test_grid_sampling.py
+++ b/test/transforms/test_grid_sampling.py
@@ -1,28 +1,18 @@
-import numpy as np
-import numpy.testing as npt
 import torch
 from torch_geometric.transforms import GridSampling
 from torch_geometric.data import Data
 
 
 def test_grid_sampling():
-    assert GridSampling(0.01, 12).__repr__() == 'GridSampling(0.01, 12)'
+    assert GridSampling(5).__repr__() == 'GridSampling(size=5)'
 
-    num_points = 5
-    num_classes = 2
+    pos = torch.Tensor([[0, 2], [3, 2], [3, 2], [2, 8], [2, 6]])
+    y = torch.tensor([0, 1, 1, 2, 2])
+    batch = torch.tensor([0, 0, 0, 0, 0])
 
-    pos = torch.Tensor([[0, 0, 0.01], [0.01, 0, 0], [0, 0.01, 0], [0, 0.01, 0], [0.01, 0, 0.01]])
-    
-    batch = torch.from_numpy(np.zeros(num_points)).long()
-    
-    y = np.asarray(np.random.randint(0, num_classes, 5))
-    uniq, counts = np.unique(y, return_counts=True)
-    answer = uniq[np.argmax(counts)]
-    
-    y = torch.from_numpy(y)
-
-    out_data = GridSampling(0.04, 2)()(Data(pos=pos, batch=batch, y=y))
-
-    out_y = out_data.y.detach().cpu().numpy()
-
-    npt.assert_array_almost_equal(answer, out_y)
+    data = Data(pos=pos, y=y, batch=batch)
+    data = GridSampling(size=5, start=0)(data)
+    assert len(data) == 3
+    assert data.pos.tolist() == [[2, 2], [2, 7]]
+    assert data.y.tolist() == [1, 2]
+    assert data.batch.tolist() == [0, 0]

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -34,6 +34,7 @@ from .generate_mesh_normals import GenerateMeshNormals
 from .delaunay import Delaunay
 from .to_superpixels import ToSLIC
 from .gdc import GDC
+from .grid_sampling import GridSampling
 
 __all__ = [
     'Compose',
@@ -72,4 +73,5 @@ __all__ = [
     'Delaunay',
     'ToSLIC',
     'GDC',
+    'GridSampling'
 ]

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -26,8 +26,7 @@ class GridSampling(object):
         batch = data.batch
 
         pool = voxel_grid(pos, batch, self._subsampling_param)
-        pool, perm = consecutive_cluster(pool)
-        data.batch = batch[perm]
+        pool, _ = consecutive_cluster(pool)
 
         for key, item in data:
             if bool(re.search('edge', key)):

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -1,0 +1,48 @@
+import re
+
+import torch
+from torch_geometric.nn import voxel_grid
+from torch_geometric.nn.pool.consecutive import consecutive_cluster
+from torch_geometric.nn.pool.pool import pool_pos, pool_batch
+from torch_scatter import scatter_add
+
+
+class GridSampling(object):
+    r"""Samples points depending on :obj:`subsampling_param`.
+
+    Args:
+        subsampling_param (int): The subsampling parameters used to map the pointcloud on a grid.
+        num_classes (int): If the data contains labels, within key `y`, then it will be used to create label grid pooling. 
+    """
+
+    def __init__(self, subsampling_param, num_classes):
+        self._subsampling_param = subsampling_param
+        self._num_classes = num_classes
+
+    def __call__(self, data):
+        num_nodes = data.num_nodes
+
+        pos = data.pos
+        batch = data.batch
+
+        pool = voxel_grid(pos, batch, self._subsampling_param)
+        pool, perm = consecutive_cluster(pool)
+        data.batch = batch[perm]
+
+        for key, item in data:
+            if bool(re.search('edge', key)):
+                continue
+
+            if torch.is_tensor(item) and item.size(0) == num_nodes:
+                if key == 'y':
+                    one_hot = torch.zeros((item.shape[0], self._num_classes))\
+                        .scatter(1, item.unsqueeze(-1), 1)
+
+                    aggr_labels = scatter_add(one_hot, pool, dim=0)
+                    data[key] = torch.argmax(aggr_labels, -1)
+                else:
+                    data[key] = pool_pos(pool, item).to(item.dtype)
+        return data
+
+    def __repr__(self):
+        return '{}({}, {})'.format(self.__class__.__name__, self._subsampling_param, self._num_classes)


### PR DESCRIPTION
This PR implements grid_sampling for pointcloud.

Given an subsampling_param and num_classes.
It fit the pointcloud to a voxel grid, select winner class for each voxel, get mean features for the other item within data and return new data.