### PR TITLE
Create train_test_split_edges utils & implement undirected negative_sampling

### DIFF
--- a/examples/autoencoder.py
+++ b/examples/autoencoder.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from torch_geometric.datasets import Planetoid
 import torch_geometric.transforms as T
 from torch_geometric.nn import GCNConv, GAE, VGAE
+from torch_geometric.utils import train_test_split_edges
 
 torch.manual_seed(12345)
 
@@ -46,7 +47,7 @@ channels = 16
 dev = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = kwargs[args.model](Encoder(dataset.num_features, channels)).to(dev)
 data.train_mask = data.val_mask = data.test_mask = data.y = None
-data = model.split_edges(data)
+data = train_test_split_edges(data)
 x, train_pos_edge_index = data.x.to(dev), data.train_pos_edge_index.to(dev)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
 

--- a/examples/link_pred.py
+++ b/examples/link_pred.py
@@ -99,5 +99,5 @@ for epoch in range(1, 501):
     if val_perf > best_val_perf:
         best_val_perf = val_perf
         test_perf = tmp_test_perf
-    log = 'Epoch: {:03d}, Train_loss: {:.4f}, Val: {:.4f}, Test: {:.4f}'
+    log = 'Epoch: {:03d}, Loss: {:.4f}, Val: {:.4f}, Test: {:.4f}'
     print(log.format(epoch, train_loss, best_val_perf, test_perf))

--- a/examples/link_pred.py
+++ b/examples/link_pred.py
@@ -1,0 +1,100 @@
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+from sklearn.metrics import roc_auc_score
+
+from torch_geometric.utils import negative_sampling, remove_self_loops, add_self_loops
+from torch_geometric.datasets import Planetoid
+import torch_geometric.transforms as T
+from torch_geometric.nn import GCNConv, ChebConv  # noqa
+from torch_geometric.utils import train_test_split_edges
+
+
+torch.manual_seed(12345)
+
+
+dataset = 'Cora'
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset)
+dataset = Planetoid(path, dataset, T.NormalizeFeatures())
+data = dataset[0]
+
+# Train/validation/test
+data.train_mask = data.val_mask = data.test_mask = data.y = None
+data = train_test_split_edges(data)
+
+
+class Net(torch.nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = GCNConv(dataset.num_features, 128)
+        self.conv2 = GCNConv(128, 64)
+
+    def forward(self, pos_edge_index, neg_edge_index):
+
+        x = F.relu(self.conv1(data.x, pos_edge_index))
+        x = self.conv2(x, pos_edge_index)
+
+        total_edge_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
+        x_j = torch.index_select(x, 0, total_edge_index[0])
+        x_i = torch.index_select(x, 0, total_edge_index[1])
+        return torch.einsum("ef,ef->e", x_i, x_j)
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model, data = Net().to(device), data.to(device)
+optimizer = torch.optim.Adam(params=model.parameters(), lr=0.01)
+
+
+def get_link_labels(pos_edge_index, neg_edge_index):
+    link_labels = torch.zeros(pos_edge_index.size(1) + neg_edge_index.size(1)).float().to(device)
+    link_labels[:pos_edge_index.size(1)] = 1.
+    return link_labels
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+
+    x, pos_edge_index = data.x, data.train_pos_edge_index
+
+    _edge_index, _ = remove_self_loops(pos_edge_index)
+    pos_edge_index_with_self_loops, _ = add_self_loops(_edge_index, num_nodes=x.size(0))
+
+    neg_edge_index = negative_sampling(
+        edge_index=pos_edge_index_with_self_loops,
+        num_nodes=x.size(0),
+        num_neg_samples=pos_edge_index.size(1))
+
+    link_logits = model(pos_edge_index, neg_edge_index)
+    link_labels = get_link_labels(pos_edge_index, neg_edge_index)
+
+    loss = F.binary_cross_entropy_with_logits(link_logits, link_labels)
+    loss.backward()
+    optimizer.step()
+
+    return loss
+
+
+def test():
+    model.eval()
+    perfs = []
+    for prefix in ["val", "test"]:
+        pos_edge_index, neg_edge_index = [index for _, index in data("{}_pos_edge_index".format(prefix),
+                                                                     "{}_neg_edge_index".format(prefix))]
+        link_probs = torch.sigmoid(model(pos_edge_index, neg_edge_index))
+        link_labels = get_link_labels(pos_edge_index, neg_edge_index)
+        link_probs, link_labels = link_probs.detach().cpu().numpy(), link_labels.detach().cpu().numpy()
+        perfs.append(roc_auc_score(link_labels, link_probs))
+    return perfs
+
+
+best_val_perf = test_perf = 0
+for epoch in range(1, 501):
+    train_loss = train()
+    val_perf, tmp_test_perf = test()
+    if val_perf > best_val_perf:
+        best_val_perf = val_perf
+        test_perf = tmp_test_perf
+    log = 'Epoch: {:03d}, Train_loss: {:.4f}, Val_perf: {:.4f}, Test_perf: {:.4f}'
+    print(log.format(epoch, train_loss, best_val_perf, test_perf))

--- a/test/nn/models/test_autoencoder.py
+++ b/test/nn/models/test_autoencoder.py
@@ -3,6 +3,7 @@ import torch
 from torch import Tensor as T
 from torch_geometric.nn import GAE, VGAE, ARGA, ARGVA
 from torch_geometric.data import Data
+from torch_geometric.utils import train_test_split_edges
 
 
 def test_gae():
@@ -25,15 +26,7 @@ def test_gae():
                                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     data = Data(edge_index=edge_index)
     data.num_nodes = edge_index.max().item() + 1
-    data = model.split_edges(data, val_ratio=0.2, test_ratio=0.3)
-
-    assert data.val_pos_edge_index.size() == (2, 2)
-    assert data.val_neg_edge_index.size() == (2, 2)
-    assert data.test_pos_edge_index.size() == (2, 3)
-    assert data.test_neg_edge_index.size() == (2, 3)
-    assert data.train_pos_edge_index.size() == (2, 10)
-    assert data.train_neg_adj_mask.size() == (11, 11)
-    assert data.train_neg_adj_mask.sum().item() == (11**2 - 11) / 2 - 4 - 6 - 5
+    data = train_test_split_edges(data, val_ratio=0.2, test_ratio=0.3)
 
     z = torch.randn(11, 16)
     loss = model.recon_loss(z, data.train_pos_edge_index)

--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -1,7 +1,8 @@
 import torch
 from torch_geometric.utils import (negative_sampling,
                                    structured_negative_sampling,
-                                   batched_negative_sampling)
+                                   batched_negative_sampling,
+                                   to_undirected, is_undirected)
 
 
 def test_negative_sampling():
@@ -19,6 +20,11 @@ def test_negative_sampling():
 
     neg_edge_index = negative_sampling(edge_index, num_neg_samples=2)
     assert neg_edge_index.size(1) == 2
+
+    undirected_edge_index = to_undirected(edge_index)
+    undirected_neg_edge_index = negative_sampling(undirected_edge_index, force_undirected=True)
+    assert is_undirected(undirected_neg_edge_index)
+    assert undirected_neg_edge_index.size(1) <= undirected_edge_index.size(1)
 
 
 def test_structured_negative_sampling():

--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -26,6 +26,13 @@ def test_negative_sampling():
     assert is_undirected(undirected_neg_edge_index)
     assert undirected_neg_edge_index.size(1) <= undirected_edge_index.size(1)
 
+    undirected_adj = torch.zeros(4, 4, dtype=torch.bool)
+    undirected_adj[undirected_edge_index[0], undirected_edge_index[1]] = 1
+
+    undirected_neg_adj = torch.zeros(4, 4, dtype=torch.bool)
+    undirected_neg_adj[undirected_neg_edge_index[0], undirected_neg_edge_index[1]] = 1
+    assert (undirected_adj & undirected_neg_adj).sum() == 0
+
 
 def test_structured_negative_sampling():
     edge_index = torch.as_tensor([[0, 0, 1, 2], [0, 1, 2, 3]])

--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -1,8 +1,8 @@
 import torch
 from torch_geometric.utils import (negative_sampling,
                                    structured_negative_sampling,
-                                   batched_negative_sampling,
-                                   to_undirected, is_undirected)
+                                   batched_negative_sampling, to_undirected,
+                                   is_undirected)
 
 
 def test_negative_sampling():
@@ -22,7 +22,8 @@ def test_negative_sampling():
     assert neg_edge_index.size(1) == 2
 
     undirected_edge_index = to_undirected(edge_index)
-    undirected_neg_edge_index = negative_sampling(undirected_edge_index, force_undirected=True)
+    undirected_neg_edge_index = negative_sampling(undirected_edge_index,
+                                                  force_undirected=True)
     assert is_undirected(undirected_neg_edge_index)
     assert undirected_neg_edge_index.size(1) <= undirected_edge_index.size(1)
 
@@ -30,7 +31,8 @@ def test_negative_sampling():
     undirected_adj[undirected_edge_index[0], undirected_edge_index[1]] = 1
 
     undirected_neg_adj = torch.zeros(4, 4, dtype=torch.bool)
-    undirected_neg_adj[undirected_neg_edge_index[0], undirected_neg_edge_index[1]] = 1
+    undirected_neg_adj[undirected_neg_edge_index[0],
+                       undirected_neg_edge_index[1]] = 1
     assert (undirected_adj & undirected_neg_adj).sum() == 0
 
 

--- a/test/utils/test_train_test_split_edges.py
+++ b/test/utils/test_train_test_split_edges.py
@@ -1,0 +1,20 @@
+import torch
+
+from torch_geometric.data import Data
+from torch_geometric.utils import train_test_split_edges
+
+
+def test_train_test_split_edges():
+    edge_index = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                               [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+    data = Data(edge_index=edge_index)
+    data.num_nodes = edge_index.max().item() + 1
+    data = train_test_split_edges(data, val_ratio=0.2, test_ratio=0.3)
+
+    assert data.val_pos_edge_index.size() == (2, 2)
+    assert data.val_neg_edge_index.size() == (2, 2)
+    assert data.test_pos_edge_index.size() == (2, 3)
+    assert data.test_neg_edge_index.size() == (2, 3)
+    assert data.train_pos_edge_index.size() == (2, 10)
+    assert data.train_neg_adj_mask.size() == (11, 11)
+    assert data.train_neg_adj_mask.sum().item() == (11**2 - 11) / 2 - 4 - 6 - 5

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -1,6 +1,6 @@
 import torch
 from sklearn.metrics import roc_auc_score, average_precision_score
-from torch_geometric.utils import negative_sampling
+from torch_geometric.utils import negative_sampling, remove_self_loops, add_self_loops
 
 from ..inits import reset
 
@@ -86,6 +86,10 @@ class GAE(torch.nn.Module):
 
         pos_loss = -torch.log(
             self.decoder(z, pos_edge_index, sigmoid=True) + EPS).mean()
+
+        # Do not include self-loops in negative samples
+        pos_edge_index, _ = remove_self_loops(pos_edge_index)
+        pos_edge_index, _ = add_self_loops(pos_edge_index)
 
         neg_edge_index = negative_sampling(pos_edge_index, z.size(0))
         neg_loss = -torch.log(1 -

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -74,12 +74,12 @@ class GAE(torch.nn.Module):
         return self.encoder(*args, **kwargs)
 
     def decode(self, *args, **kwargs):
-        r"""Runs the decoder and computes edge probabilties."""
+        r"""Runs the decoder and computes edge probabilities."""
         return self.decoder(*args, **kwargs)
 
     def split_edges(self, data, val_ratio=0.05, test_ratio=0.1):
         r"""Splits the edges of a :obj:`torch_geometric.data.Data` object
-        into positve and negative train/val/test edges.
+        into positive and negative train/val/test edges.
 
         Args:
             data (Data): The data object.

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -1,6 +1,7 @@
 import torch
 from sklearn.metrics import roc_auc_score, average_precision_score
-from torch_geometric.utils import negative_sampling, remove_self_loops, add_self_loops
+from torch_geometric.utils import (negative_sampling, remove_self_loops,
+                                   add_self_loops)
 
 from ..inits import reset
 

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -1,9 +1,6 @@
-import math
-import random
-
 import torch
 from sklearn.metrics import roc_auc_score, average_precision_score
-from torch_geometric.utils import to_undirected, negative_sampling
+from torch_geometric.utils import negative_sampling
 
 from ..inits import reset
 
@@ -76,67 +73,6 @@ class GAE(torch.nn.Module):
     def decode(self, *args, **kwargs):
         r"""Runs the decoder and computes edge probabilities."""
         return self.decoder(*args, **kwargs)
-
-    def split_edges(self, data, val_ratio=0.05, test_ratio=0.1):
-        r"""Splits the edges of a :obj:`torch_geometric.data.Data` object
-        into positive and negative train/val/test edges.
-
-        Args:
-            data (Data): The data object.
-            val_ratio (float, optional): The ratio of positive validation
-                edges. (default: :obj:`0.05`)
-            test_ratio (float, optional): The ratio of positive test
-                edges. (default: :obj:`0.1`)
-        """
-
-        assert 'batch' not in data  # No batch-mode.
-
-        row, col = data.edge_index
-        data.edge_index = None
-
-        # Return upper triangular portion.
-        mask = row < col
-        row, col = row[mask], col[mask]
-
-        n_v = int(math.floor(val_ratio * row.size(0)))
-        n_t = int(math.floor(test_ratio * row.size(0)))
-
-        # Positive edges.
-        perm = torch.randperm(row.size(0))
-        row, col = row[perm], col[perm]
-
-        r, c = row[:n_v], col[:n_v]
-        data.val_pos_edge_index = torch.stack([r, c], dim=0)
-        r, c = row[n_v:n_v + n_t], col[n_v:n_v + n_t]
-        data.test_pos_edge_index = torch.stack([r, c], dim=0)
-
-        r, c = row[n_v + n_t:], col[n_v + n_t:]
-        data.train_pos_edge_index = torch.stack([r, c], dim=0)
-        data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
-
-        # Negative edges.
-        num_nodes = data.num_nodes
-        neg_adj_mask = torch.ones(num_nodes, num_nodes, dtype=torch.uint8)
-        neg_adj_mask = neg_adj_mask.triu(diagonal=1).to(torch.bool)
-        neg_adj_mask[row, col] = 0
-
-        neg_row, neg_col = neg_adj_mask.nonzero().t()
-        perm = random.sample(range(neg_row.size(0)),
-                             min(n_v + n_t, neg_row.size(0)))
-        perm = torch.tensor(perm)
-        perm = perm.to(torch.long)
-        neg_row, neg_col = neg_row[perm], neg_col[perm]
-
-        neg_adj_mask[neg_row, neg_col] = 0
-        data.train_neg_adj_mask = neg_adj_mask
-
-        row, col = neg_row[:n_v], neg_col[:n_v]
-        data.val_neg_edge_index = torch.stack([row, col], dim=0)
-
-        row, col = neg_row[n_v:n_v + n_t], neg_col[n_v:n_v + n_t]
-        data.test_neg_edge_index = torch.stack([row, col], dim=0)
-
-        return data
 
     def recon_loss(self, z, pos_edge_index):
         r"""Given latent variables :obj:`z`, computes the binary cross

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -24,6 +24,7 @@ from .random import (erdos_renyi_graph, stochastic_blockmodel_graph,
 from .negative_sampling import (negative_sampling,
                                 structured_negative_sampling,
                                 batched_negative_sampling)
+from .train_test_split_edges import train_test_split_edges
 from .metric import (accuracy, true_positive, true_negative, false_positive,
                      false_negative, precision, recall, f1_score,
                      intersection_and_union, mean_iou)
@@ -63,6 +64,7 @@ __all__ = [
     'negative_sampling',
     'structured_negative_sampling',
     'batched_negative_sampling',
+    'train_test_split_edges',
     'accuracy',
     'true_positive',
     'true_negative',

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -60,7 +60,7 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None,
 
     if force_undirected:
         # (-sqrt((2 * N + 1)^2 - 8 * perm) + 2 * N + 1) / 2
-        row = torch.floor((-torch.sqrt((2 * num_nodes + 1)**2 - 8 * perm) +
+        row = torch.floor((-torch.sqrt((2. * num_nodes + 1.)**2 - 8. * perm) +
                            2 * num_nodes + 1) / 2)
         col = perm - row * (2 * num_nodes - row - 1) // 2
         neg_edge_index = torch.stack([row, col], dim=0).long()

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -7,7 +7,8 @@ from torch_geometric.utils import degree, to_undirected
 from .num_nodes import maybe_num_nodes
 
 
-def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_undirected=False):
+def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None,
+                      force_undirected=False):
     r"""Samples random negative edges of a graph given by :attr:`edge_index`.
 
     Args:
@@ -17,8 +18,8 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_un
         num_neg_samples (int, optional): The number of negative samples to
             return. If set to :obj:`None`, will try to return a negative edge
             for every positive edge. (default: :obj:`None`)
-        force_undirected (bool, optional): If set to :obj:`True`, sampled negative
-            edges will be undirected. (default: :obj:`False`)
+        force_undirected (bool, optional): If set to :obj:`True`, sampled
+            negative edges will be undirected. (default: :obj:`False`)
 
     :rtype: LongTensor
     """
@@ -32,12 +33,14 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_un
 
     if force_undirected:
         num_neg_samples = num_neg_samples // 2
-        rng = range((num_nodes * (num_nodes + 1)) // 2)  # Upper triangle indices: N + ... + 1 = N (N + 1) / 2
-        edge_index = edge_index[:, edge_index[0] <= edge_index[1]]  # Remove edges in the lower triangle matrix
-        idx = (edge_index[0] * num_nodes + edge_index[1]
-               - edge_index[0] * (edge_index[0] + 1) // 2).to('cpu')  # Ni + j - i(i+1)/2
+        rng = range((num_nodes * (num_nodes + 1)) //
+                    2)  # Upper triangle indices: N + ... + 1 = N (N + 1) / 2
+        edge_index = edge_index[:, edge_index[0] <= edge_index[
+            1]]  # Remove edges in the lower triangle matrix
+        idx = (edge_index[0] * num_nodes + edge_index[1] - edge_index[0] *
+               (edge_index[0] + 1) // 2).to('cpu')  # Ni + j - i(i+1)/2
     else:
-        rng = range(num_nodes ** 2)
+        rng = range(num_nodes**2)
         idx = (edge_index[0] * num_nodes + edge_index[1]).to('cpu')  # Ni + j
 
     perm = torch.tensor(random.sample(rng, num_neg_samples))
@@ -50,7 +53,9 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_un
         rest = rest[mask.nonzero().view(-1)]
 
     if force_undirected:
-        row = np.floor((-np.sqrt((2 * num_nodes + 1) ** 2 - 8 * perm) + 2 * num_nodes + 1) / 2)
+        row = np.floor(
+            (-np.sqrt((2 * num_nodes + 1)**2 - 8 * perm) + 2 * num_nodes + 1) /
+            2)
         col = perm - row * (2 * num_nodes - row - 1) // 2
         neg_edge_index = torch.stack([row, col], dim=0).long()
         neg_edge_index = to_undirected(neg_edge_index)
@@ -93,7 +98,8 @@ def structured_negative_sampling(edge_index, num_nodes=None):
     return edge_index[0], edge_index[1], k.to(edge_index.device)
 
 
-def batched_negative_sampling(edge_index, batch, num_neg_samples=None, force_undirected=False):
+def batched_negative_sampling(edge_index, batch, num_neg_samples=None,
+                              force_undirected=False):
     r"""Samples random negative edges of multiple graphs given by
     :attr:`edge_index` and :attr:`batch`.
 
@@ -105,8 +111,8 @@ def batched_negative_sampling(edge_index, batch, num_neg_samples=None, force_und
         num_neg_samples (int, optional): The number of negative samples to
             return. If set to :obj:`None`, will try to return a negative edge
             for every positive edge. (default: :obj:`None`)
-        force_undirected (bool, optional): If set to :obj:`True`, sampled negative
-            edges will be undirected. (default: :obj:`False`)
+        force_undirected (bool, optional): If set to :obj:`True`, sampled
+            negative edges will be undirected. (default: :obj:`False`)
 
     :rtype: LongTensor
     """
@@ -118,8 +124,8 @@ def batched_negative_sampling(edge_index, batch, num_neg_samples=None, force_und
     neg_edge_indices = []
     for edge_index, N, C in zip(edge_indices, num_nodes.tolist(),
                                 cum_nodes.tolist()):
-        neg_edge_index = negative_sampling(edge_index - C, N,
-                                           num_neg_samples, force_undirected) + C
+        neg_edge_index = negative_sampling(edge_index - C, N, num_neg_samples,
+                                           force_undirected) + C
         neg_edge_indices.append(neg_edge_index)
 
     return torch.cat(neg_edge_indices, dim=1)

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -2,12 +2,12 @@ import random
 
 import torch
 import numpy as np
-from torch_geometric.utils import degree
+from torch_geometric.utils import degree, to_undirected
 
 from .num_nodes import maybe_num_nodes
 
 
-def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None):
+def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_undirected=False):
     r"""Samples random negative edges of a graph given by :attr:`edge_index`.
 
     Args:
@@ -17,6 +17,8 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None):
         num_neg_samples (int, optional): The number of negative samples to
             return. If set to :obj:`None`, will try to return a negative edge
             for every positive edge. (default: :obj:`None`)
+        force_undirected (bool, optional): If set to :obj:`True`, sampled negative
+            edges will be undirected. (default: :obj:`False`)
 
     :rtype: LongTensor
     """
@@ -24,13 +26,19 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None):
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
     num_neg_samples = num_neg_samples or edge_index.size(1)
 
-    # Handle '2*|edges| > num_nodes^2' case.
+    # Handle '|V|^2 - |E| < |E|' case for G = (V, E).
     num_neg_samples = min(num_neg_samples,
                           num_nodes * num_nodes - edge_index.size(1))
 
+    if force_undirected:
+        num_neg_samples = num_neg_samples // 2
+        ut_edge_index = torch.ones(num_nodes, num_nodes).triu(diagonal=0).nonzero().t()  # upper triangle
+        rng = list(ut_edge_index[0] * num_nodes + ut_edge_index[1])
+    else:
+        rng = range(num_nodes ** 2)
+
     idx = (edge_index[0] * num_nodes + edge_index[1]).to('cpu')
 
-    rng = range(num_nodes**2)
     perm = torch.tensor(random.sample(rng, num_neg_samples))
     mask = torch.from_numpy(np.isin(perm, idx)).to(torch.bool)
     rest = mask.nonzero().view(-1)
@@ -41,7 +49,11 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None):
         rest = rest[mask.nonzero().view(-1)]
 
     row, col = perm / num_nodes, perm % num_nodes
-    return torch.stack([row, col], dim=0).long().to(edge_index.device)
+    neg_edge_index = torch.stack([row, col], dim=0).long()
+
+    if force_undirected:
+        neg_edge_index = to_undirected(neg_edge_index)
+    return neg_edge_index.to(edge_index.device)
 
 
 def structured_negative_sampling(edge_index, num_nodes=None):
@@ -76,7 +88,7 @@ def structured_negative_sampling(edge_index, num_nodes=None):
     return edge_index[0], edge_index[1], k.to(edge_index.device)
 
 
-def batched_negative_sampling(edge_index, batch, num_neg_samples=None):
+def batched_negative_sampling(edge_index, batch, num_neg_samples=None, force_undirected=False):
     r"""Samples random negative edges of multiple graphs given by
     :attr:`edge_index` and :attr:`batch`.
 
@@ -88,6 +100,8 @@ def batched_negative_sampling(edge_index, batch, num_neg_samples=None):
         num_neg_samples (int, optional): The number of negative samples to
             return. If set to :obj:`None`, will try to return a negative edge
             for every positive edge. (default: :obj:`None`)
+        force_undirected (bool, optional): If set to :obj:`True`, sampled negative
+            edges will be undirected. (default: :obj:`False`)
 
     :rtype: LongTensor
     """
@@ -100,7 +114,7 @@ def batched_negative_sampling(edge_index, batch, num_neg_samples=None):
     for edge_index, N, C in zip(edge_indices, num_nodes.tolist(),
                                 cum_nodes.tolist()):
         neg_edge_index = negative_sampling(edge_index - C, N,
-                                           num_neg_samples) + C
+                                           num_neg_samples, force_undirected) + C
         neg_edge_indices.append(neg_edge_index)
 
     return torch.cat(neg_edge_indices, dim=1)

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -32,8 +32,7 @@ def negative_sampling(edge_index, num_nodes=None, num_neg_samples=None, force_un
 
     if force_undirected:
         num_neg_samples = num_neg_samples // 2
-        ut_edge_index = torch.ones(num_nodes, num_nodes).triu(diagonal=0).nonzero().t()  # upper triangle
-        rng = list(ut_edge_index[0] * num_nodes + ut_edge_index[1])
+        rng = [num_nodes * i + j for i in range(num_nodes) for j in range(i, num_nodes)]  # upper triangle
     else:
         rng = range(num_nodes ** 2)
 

--- a/torch_geometric/utils/train_test_split_edges.py
+++ b/torch_geometric/utils/train_test_split_edges.py
@@ -1,0 +1,71 @@
+import math
+import random
+import torch
+from torch_geometric.utils import to_undirected
+
+
+def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
+    r"""Splits the edges of a :obj:`torch_geometric.data.Data` object
+    into positive and negative train/val/test edges, and adds attributes of
+    `train_pos_edge_index`, `train_neg_adj_mask`, `val_pos_edge_index`,
+    `val_neg_edge_index`, `test_pos_edge_index`, and `test_neg_edge_index`
+    to :attr:`data`.
+
+    Args:
+        data (Data): The data object.
+        val_ratio (float, optional): The ratio of positive validation
+            edges. (default: :obj:`0.05`)
+        test_ratio (float, optional): The ratio of positive test
+            edges. (default: :obj:`0.1`)
+
+    :rtype: :class:`torch_geometric.data.Data`
+    """
+
+    assert 'batch' not in data  # No batch-mode.
+
+    row, col = data.edge_index
+    data.edge_index = None
+
+    # Return upper triangular portion.
+    mask = row < col
+    row, col = row[mask], col[mask]
+
+    n_v = int(math.floor(val_ratio * row.size(0)))
+    n_t = int(math.floor(test_ratio * row.size(0)))
+
+    # Positive edges.
+    perm = torch.randperm(row.size(0))
+    row, col = row[perm], col[perm]
+
+    r, c = row[:n_v], col[:n_v]
+    data.val_pos_edge_index = torch.stack([r, c], dim=0)
+    r, c = row[n_v:n_v + n_t], col[n_v:n_v + n_t]
+    data.test_pos_edge_index = torch.stack([r, c], dim=0)
+
+    r, c = row[n_v + n_t:], col[n_v + n_t:]
+    data.train_pos_edge_index = torch.stack([r, c], dim=0)
+    data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
+
+    # Negative edges.
+    num_nodes = data.num_nodes
+    neg_adj_mask = torch.ones(num_nodes, num_nodes, dtype=torch.uint8)
+    neg_adj_mask = neg_adj_mask.triu(diagonal=1).to(torch.bool)
+    neg_adj_mask[row, col] = 0
+
+    neg_row, neg_col = neg_adj_mask.nonzero().t()
+    perm = random.sample(range(neg_row.size(0)),
+                         min(n_v + n_t, neg_row.size(0)))
+    perm = torch.tensor(perm)
+    perm = perm.to(torch.long)
+    neg_row, neg_col = neg_row[perm], neg_col[perm]
+
+    neg_adj_mask[neg_row, neg_col] = 0
+    data.train_neg_adj_mask = neg_adj_mask
+
+    row, col = neg_row[:n_v], neg_col[:n_v]
+    data.val_neg_edge_index = torch.stack([row, col], dim=0)
+
+    row, col = neg_row[n_v:n_v + n_t], neg_col[n_v:n_v + n_t]
+    data.test_neg_edge_index = torch.stack([row, col], dim=0)
+
+    return data


### PR DESCRIPTION
1. Separate split_edges in GAE to the individual util (train_test_split_edges). This can be globally used for the link prediction task. I also add a link prediction example (link_preds.py).
2. Exclude self-loops in sampling negative edges for GAE.
3. Implement negative_sampling with force_undirected. This is a draft, and we have to discuss some design choices.
    - I first set num_neg_samples to half of the num_neg_samples given [[1]](https://github.com/dongkwan-kim/pytorch_geometric/blob/master/torch_geometric/utils/negative_sampling.py#L34), then make them undirected at the last line of function [[2]](https://github.com/dongkwan-kim/pytorch_geometric/blob/master/torch_geometric/utils/negative_sampling.py#L55). Since `edge_index.size(1)` is the common way to get the number of edges in PYG,  I think it is natural for end-users to set `num_neg_samples` to the real size of `edge_index`. But in our current implementation, `perm` contains duplicated indices and self-loop indices. So if we apply to_undirected, we might get negative edges the size of which is smaller than `num_neg_samples`. What do you think about this?


