### PR TITLE
Small tweak in utils.to_networkx

### DIFF
--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -46,14 +46,16 @@ def test_to_networkx():
     edge_attr = torch.Tensor([1, 2, 3])
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
-    for condition_sl in [True, False]:
+    for remove_self_loops in [True, False]:
         G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
-                        remove_self_loops=condition_sl)
+                        remove_self_loops=remove_self_loops)
+
         assert G.nodes[0]['x'] == [1, 2]
         assert G.nodes[1]['x'] == [3, 4]
         assert G.nodes[0]['pos'] == [0, 0]
         assert G.nodes[1]['pos'] == [1, 1]
-        if condition_sl:
+
+        if remove_self_loops:
             assert nx.to_numpy_matrix(G).tolist() == [[0, 1], [2, 0]]
         else:
             assert nx.to_numpy_matrix(G).tolist() == [[3, 1], [2, 0]]
@@ -66,15 +68,17 @@ def test_to_networkx_undirected():
     edge_attr = torch.Tensor([1, 2, 3])
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
-    for condition_sl in [True, False]:
+    for remove_self_loops in [True, False]:
         G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
-                        remove_self_loops=condition_sl,
+                        remove_self_loops=remove_self_loops,
                         to_undirected=True)
+
         assert G.nodes[0]['x'] == [1, 2]
         assert G.nodes[1]['x'] == [3, 4]
         assert G.nodes[0]['pos'] == [0, 0]
         assert G.nodes[1]['pos'] == [1, 1]
-        if condition_sl:
+
+        if remove_self_loops:
             assert nx.to_numpy_matrix(G).tolist() == [[0, 2], [2, 0]]
         else:
             assert nx.to_numpy_matrix(G).tolist() == [[3, 2], [2, 0]]

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -2,6 +2,7 @@ import torch
 import scipy.sparse
 import networkx as nx
 from torch_sparse import coalesce
+
 from torch_geometric.data import Data
 from torch_geometric.utils import (to_scipy_sparse_matrix,
                                    from_scipy_sparse_matrix)
@@ -46,7 +47,8 @@ def test_to_networkx():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for condition_sl in [True, False]:
-        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'], remove_self_loops=condition_sl)
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
+                        remove_self_loops=condition_sl)
         assert G.nodes[0]['x'] == [1, 2]
         assert G.nodes[1]['x'] == [3, 4]
         assert G.nodes[0]['pos'] == [0, 0]
@@ -65,7 +67,8 @@ def test_to_networkx_undirected():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for condition_sl in [True, False]:
-        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'], remove_self_loops=condition_sl,
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
+                        remove_self_loops=condition_sl,
                         to_undirected=True)
         assert G.nodes[0]['x'] == [1, 2]
         assert G.nodes[1]['x'] == [3, 4]

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -45,12 +45,36 @@ def test_to_networkx():
     edge_attr = torch.Tensor([1, 2, 3])
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
-    G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'])
-    assert G.nodes[0]['x'] == [1, 2]
-    assert G.nodes[1]['x'] == [3, 4]
-    assert G.nodes[0]['pos'] == [0, 0]
-    assert G.nodes[1]['pos'] == [1, 1]
-    assert nx.to_numpy_matrix(G).tolist() == [[3, 1], [2, 0]]
+    for condition_sl in [True, False]:
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'], remove_self_loops=condition_sl)
+        assert G.nodes[0]['x'] == [1, 2]
+        assert G.nodes[1]['x'] == [3, 4]
+        assert G.nodes[0]['pos'] == [0, 0]
+        assert G.nodes[1]['pos'] == [1, 1]
+        if condition_sl:
+            assert nx.to_numpy_matrix(G).tolist() == [[0, 1], [2, 0]]
+        else:
+            assert nx.to_numpy_matrix(G).tolist() == [[3, 1], [2, 0]]
+
+
+def test_to_networkx_undirected():
+    x = torch.Tensor([[1, 2], [3, 4]])
+    pos = torch.Tensor([[0, 0], [1, 1]])
+    edge_index = torch.tensor([[0, 1, 0], [1, 0, 0]])
+    edge_attr = torch.Tensor([1, 2, 3])
+    data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
+
+    for condition_sl in [True, False]:
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'], remove_self_loops=condition_sl,
+                        to_undirected=True)
+        assert G.nodes[0]['x'] == [1, 2]
+        assert G.nodes[1]['x'] == [3, 4]
+        assert G.nodes[0]['pos'] == [0, 0]
+        assert G.nodes[1]['pos'] == [1, 1]
+        if condition_sl:
+            assert nx.to_numpy_matrix(G).tolist() == [[0, 2], [2, 0]]
+        else:
+            assert nx.to_numpy_matrix(G).tolist() == [[3, 2], [2, 0]]
 
 
 def test_from_networkx():

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -62,27 +62,30 @@ def to_networkx(data, node_attrs=None, edge_attrs=None, to_undirected=False,
             copied. (default: :obj:`None`)
         edge_attrs (iterable of str, optional): The edge attributes to be
             copied. (default: :obj:`None`)
-        to_undirected (bool, optional): If set to :obj:`True`, it will return
-            a :obj:`networkx.Graph`. In practice, the undirected graph will
-            correspond to the upper triangle of the corresponding adjacency
-            matrix. (default: :obj:`False`)
-        remove_self_loops (bool, optional): If set to :obj:`True`, it will not
-            include self loops in the returning graph. (default: :obj:`False`)
+        to_undirected (bool, optional): If set to :obj:`True`, will return a
+            a :obj:`networkx.Graph` instead of a :obj:`networkx.DiGraph`. The
+            undirected graph will correspond to the upper triangle of the
+            corresponding adjacency matrix. (default: :obj:`False`)
+        remove_self_loops (bool, optional): If set to :obj:`True`, will not
+            include self loops in the resulting graph. (default: :obj:`False`)
     """
 
     if to_undirected:
         G = nx.Graph()
     else:
         G = nx.DiGraph()
-    G.add_nodes_from(range(data.num_nodes))
 
+    G.add_nodes_from(range(data.num_nodes))
     values = {key: data[key].squeeze().tolist() for key in data.keys}
 
     for i, (u, v) in enumerate(data.edge_index.t().tolist()):
+
         if to_undirected and v > u:
             continue
-        if u == v and remove_self_loops:
+
+        if remove_self_loops and u == v:
             continue
+
         G.add_edge(u, v)
         for key in edge_attrs if edge_attrs is not None else []:
             G[u][v][key] = values[key][i]

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -1,6 +1,7 @@
 import torch
 import scipy.sparse
 import networkx as nx
+
 import torch_geometric.data
 
 try:
@@ -49,10 +50,11 @@ def from_scipy_sparse_matrix(A):
     return edge_index, edge_weight
 
 
-def to_networkx(data, node_attrs=None, edge_attrs=None, to_undirected=False, remove_self_loops=False):
+def to_networkx(data, node_attrs=None, edge_attrs=None, to_undirected=False,
+                remove_self_loops=False):
     r"""Converts a :class:`torch_geometric.data.Data` instance to a
-    :obj:`networkx.DiGraph` if :attr:`to_undirected` is set to :obj:`True`, or an undirected
-    :obj:`networkx.Graph` otherwise.
+    :obj:`networkx.DiGraph` if :attr:`to_undirected` is set to :obj:`True`, or
+    an undirected :obj:`networkx.Graph` otherwise.
 
     Args:
         data (torch_geometric.data.Data): The data object.
@@ -60,11 +62,12 @@ def to_networkx(data, node_attrs=None, edge_attrs=None, to_undirected=False, rem
             copied. (default: :obj:`None`)
         edge_attrs (iterable of str, optional): The edge attributes to be
             copied. (default: :obj:`None`)
-        to_undirected (bool, optional): If set to :obj:`True`, it will return a :obj:`networkx.Graph`.
-            In practice, the undirected graph will correspond to the upper triangle of the
-            corresponding adjacency matrix. (default: :obj:`False`)
-        remove_self_loops (bool, optional): If set to :obj:`True`, it will not include self loops in
-            the returning graph.  (default: :obj:`False`)
+        to_undirected (bool, optional): If set to :obj:`True`, it will return
+            a :obj:`networkx.Graph`. In practice, the undirected graph will
+            correspond to the upper triangle of the corresponding adjacency
+            matrix. (default: :obj:`False`)
+        remove_self_loops (bool, optional): If set to :obj:`True`, it will not
+            include self loops in the returning graph. (default: :obj:`False`)
     """
 
     if to_undirected:


### PR DESCRIPTION
PR from discussion in #1005.

I basically added option to return an undirected Graph, and the option to remove self loops, with documentation.

I have added a few tests:
1. Changed previous test to include with and without removing self loops
2. An extra test for undirected graphs

For the test with the undirected graphs there is the issue that one edge attribute is lost, but that is something that cannot be avoided (I think) if the person starts already with a graph that is not exactly undirected in its attributes. In any case, I've added the assert as in the documentation I wrote "the undirected graph will correspond to the upper triangle of the corresponding adjacency matrix".