### PR TITLE
Fix out of index issue in topk.

### DIFF
--- a/torch_geometric/nn/pool/topk_pool.py
+++ b/torch_geometric/nn/pool/topk_pool.py
@@ -25,7 +25,8 @@ def topk(x, ratio, batch, min_score=None, tol=1e-7):
         index = torch.arange(batch.size(0), dtype=torch.long, device=x.device)
         index = (index - cum_num_nodes[batch]) + (batch * max_num_nodes)
 
-        dense_x = x.new_full((batch_size * max_num_nodes, ), -2)
+        dense_x = x.new_full((batch_size * max_num_nodes, ),
+                             torch.finfo(x.dtype).min)
         dense_x[index] = x
         dense_x = dense_x.view(batch_size, max_num_nodes)
 


### PR DESCRIPTION
In topk, it makes dense and fixed node tensor according to x.shape and initialize all values to -2.
So, a graph which is smaller than biggest graph in batch has dummy nodes.
And then, x is copied to dense tensor and ordered by score.
If some scores in a graph which is smaller than biggest graph are smaller than -2,
they are moved to out of node size of original graph and dummy nodes are filled to those position.
So, returned perm has dummy node that have out of index.

Actually, this error was occurred in my custom dataset using SAGPool and I fixed the problem by this code.