### PR TITLE
Fix small bug for batch sizes of one in torch_geometric.data.Dataset.

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -198,6 +198,8 @@ class Dataset(torch.utils.data.Dataset):
             indices = indices[idx]
         elif torch.is_tensor(idx):
             if idx.dtype == torch.long:
+                if len(idx.shape) == 0:
+                    idx = idx.unsqueeze(0)
                 return self.index_select(idx.tolist())
             elif idx.dtype == torch.bool or idx.dtype == torch.uint8:
                 return self.index_select(idx.nonzero().flatten().tolist())


### PR DESCRIPTION
This PR fixes a bug encountered with batch sizes of one.

`idx.tolist()` would yield a number rather than a list since the tensor was of dimension 0.

Fixed with an unsqueeze.