### PR TITLE
Add installation of dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg2 curl && \
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+    
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils gnupg2 curl && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
     echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
     echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list &&\


### PR DESCRIPTION
Added installation of apt-transport-https ca-certificates at the top of the file, lack of these dependencies were throwing The method driver /usr/lib/apt/methods/https could not be found