### PR TITLE
Use 1-D convolution after sort_pool

### DIFF
--- a/benchmark/kernel/sort_pool.py
+++ b/benchmark/kernel/sort_pool.py
@@ -1,24 +1,26 @@
 import torch
 import torch.nn.functional as F
-from torch.nn import Linear
+from torch.nn import Linear, Conv1d
 from torch_geometric.nn import SAGEConv, global_sort_pool
 
 
 class SortPool(torch.nn.Module):
     def __init__(self, dataset, num_layers, hidden):
         super(SortPool, self).__init__()
-        self.k = 10
+        self.k = 30
         self.conv1 = SAGEConv(dataset.num_features, hidden)
         self.convs = torch.nn.ModuleList()
         for i in range(num_layers - 1):
             self.convs.append(SAGEConv(hidden, hidden))
-        self.lin1 = Linear(self.k * hidden, hidden)
+        self.conv1d = Conv1d(hidden, 32, 5)
+        self.lin1 = Linear(32 * (self.k - 5 + 1), hidden)
         self.lin2 = Linear(hidden, dataset.num_classes)
 
     def reset_parameters(self):
         self.conv1.reset_parameters()
         for conv in self.convs:
             conv.reset_parameters()
+        self.conv1d.reset_parameters()
         self.lin1.reset_parameters()
         self.lin2.reset_parameters()
 
@@ -28,6 +30,9 @@ class SortPool(torch.nn.Module):
         for conv in self.convs:
             x = F.relu(conv(x, edge_index))
         x = global_sort_pool(x, batch, self.k)
+        x = x.view(len(x), self.k, -1).permute(0, 2, 1)
+        x = F.relu(self.conv1d(x))
+        x = x.view(len(x), -1)
         x = F.relu(self.lin1(x))
         x = F.dropout(x, p=0.5, training=self.training)
         x = self.lin2(x)


### PR DESCRIPTION
Hi Matthias, 

Thank you for implementing sort_pool in PyG. I noticed that sort_pool is not correctly used in graph classification benchmarking experiments. After sort_pool, we get a sequence of node representations, where 1-D convolution is supposed to be applied to the sequence to learn meaningful information (like using 1-D convolution on time series), instead of concatenating them and applying MLP.

In this PR, I modify `sort_pool.py` a bit to add a simple 1-D convolution layer after sort_pool, for people referring to this repository to get a good sense of how to use sort_pool. The graph classification performance improves moderately. 

| Accuracy     | MUTAG        | PROTEINS           | COLLAB  |   IMDB-BINARY  | REDDIT-BINARY |
| ------------- |-------------|-------------|-------------|-------------|-------------|
| Before      |  77.3 ± 8.9 | 72.4 ± 4.1 | 77.7 ± 3.1 | 72.4 ± 3.8 | 74.9 ± 6.7 |
| After        |  81.4 ± 7.1 | 74.2 ± 3.8 |  78.3 ± 1.1 | 72.2 ± 5.7 | 81.5 ± 3.3 | 

There are also other differences from how I used sort_pool in DGCNN. I tried to reimplement DGCNN in PyG, and can get an 80.6 accuacy on COLLAB and 89.5 accuracy on REDDIT-BINARY. But I think it is not the purpose here. 

Thank you in advance for your time!