### PR TITLE
Changed files_exist to return False if files list is empty

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -16,7 +16,7 @@ def to_list(x):
 
 
 def files_exist(files):
-    return all([osp.exists(f) for f in files])
+    return len(files) != 0 and all([osp.exists(f) for f in files])
 
 
 def __repr__(obj):


### PR DESCRIPTION
Hi,

I suggest this fix since Python's all() returns True for empty input list.
In case processed_dir doesn't exist/empty before Dataset init call, _process() will return prior to creating processed_dir and calling self.process.

Best regards,
Itsik