### PR TITLE
Store GAT attention and edge_index

### DIFF
--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -13,7 +13,7 @@ def test_gat_conv():
     assert conv(x, edge_index).size() == (num_nodes, 2 * out_channels)
     assert conv((x, None), edge_index).size() == (num_nodes, 2 * out_channels)
 
-    out = conv.get_attention_weight(x, edge_index)
+    out = conv.get_attention_weight()
     assert out[0].size() == (2, edge_index.size(1) + num_nodes)
     assert out[1].size() == (edge_index.size(1) + num_nodes, conv.heads)
 
@@ -21,6 +21,6 @@ def test_gat_conv():
     assert conv(x, edge_index).size() == (num_nodes, out_channels)
     assert conv((x, None), edge_index).size() == (num_nodes, out_channels)
 
-    out = conv.get_attention_weight(x, edge_index)
+    out = conv.get_attention_weight()
     assert out[0].size() == (2, edge_index.size(1) + num_nodes)
     assert out[1].size() == (edge_index.size(1) + num_nodes, conv.heads)

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -13,14 +13,16 @@ def test_gat_conv():
     assert conv(x, edge_index).size() == (num_nodes, 2 * out_channels)
     assert conv((x, None), edge_index).size() == (num_nodes, 2 * out_channels)
 
-    out = conv.get_attention_weight()
-    assert out[0].size() == (2, edge_index.size(1) + num_nodes)
-    assert out[1].size() == (edge_index.size(1) + num_nodes, conv.heads)
+    out = conv(x, edge_index, return_attention_weights=True)
+    assert out[0].size() == (num_nodes, 2 * out_channels)
+    assert out[1][0].size() == (edge_index.size(1) + num_nodes, 2)
+    assert conv.__alpha__ is None
 
     conv = GATConv(in_channels, out_channels, heads=2, concat=False)
     assert conv(x, edge_index).size() == (num_nodes, out_channels)
     assert conv((x, None), edge_index).size() == (num_nodes, out_channels)
 
-    out = conv.get_attention_weight()
-    assert out[0].size() == (2, edge_index.size(1) + num_nodes)
-    assert out[1].size() == (edge_index.size(1) + num_nodes, conv.heads)
+    out = conv(x, edge_index, return_attention_weights=True)
+    assert out[0].size() == (num_nodes, out_channels)
+    assert out[1][0].size() == (edge_index.size(1) + num_nodes, 2)
+    assert conv.__alpha__ is None

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -15,7 +15,7 @@ def test_gat_conv():
 
     out = conv(x, edge_index, return_attention_weights=True)
     assert out[0].size() == (num_nodes, 2 * out_channels)
-    assert out[1][0].size() == (edge_index.size(1) + num_nodes, 2)
+    assert out[1][1].size() == (edge_index.size(1) + num_nodes, 2)
     assert conv.__alpha__ is None
 
     conv = GATConv(in_channels, out_channels, heads=2, concat=False)
@@ -24,5 +24,5 @@ def test_gat_conv():
 
     out = conv(x, edge_index, return_attention_weights=True)
     assert out[0].size() == (num_nodes, out_channels)
-    assert out[1][0].size() == (edge_index.size(1) + num_nodes, 2)
+    assert out[1][1].size() == (edge_index.size(1) + num_nodes, 2)
     assert conv.__alpha__ is None

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -56,7 +56,7 @@ class GATConv(MessagePassing):
         self.concat = concat
         self.negative_slope = negative_slope
         self.dropout = dropout
-        
+
         self.__alpha__ = None
 
         self.weight = Parameter(torch.Tensor(in_channels,
@@ -96,7 +96,7 @@ class GATConv(MessagePassing):
 
         if return_attention_weights:
             alpha, self.__alpha__ = self.__alpha__, None
-            return out, (alpha, edge_index)
+            return out, (edge_index, alpha)
         else:
             return out
 

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -56,7 +56,8 @@ class GATConv(MessagePassing):
         self.concat = concat
         self.negative_slope = negative_slope
         self.dropout = dropout
-        self.__save_att__ = False
+        self.__edge_index__ = None
+        self.__alpha__ = None
 
         self.weight = Parameter(torch.Tensor(in_channels,
                                              heads * out_channels))
@@ -76,15 +77,13 @@ class GATConv(MessagePassing):
         glorot(self.att)
         zeros(self.bias)
 
-    def forward(self, x, edge_index, size=None):
+    def forward(self, x, edge_index, size=None,
+                store_attention_weights=False):
         """"""
         if size is None and torch.is_tensor(x):
             edge_index, _ = remove_self_loops(edge_index)
             edge_index, _ = add_self_loops(edge_index,
                                            num_nodes=x.size(self.node_dim))
-
-        if self.__save_att__:
-            self.__edge_index__ = edge_index
 
         if torch.is_tensor(x):
             x = torch.matmul(x, self.weight)
@@ -92,9 +91,12 @@ class GATConv(MessagePassing):
             x = (None if x[0] is None else torch.matmul(x[0], self.weight),
                  None if x[1] is None else torch.matmul(x[1], self.weight))
 
+        if store_attention_weights:
+            self.__edge_index__ = edge_index
+
         return self.propagate(edge_index, size=size, x=x)
 
-    def message(self, edge_index_i, x_i, x_j, size_i):
+    def message(self, edge_index_i, x_i, x_j, size_i, store_attention_weights):
         # Compute attention coefficients.
         x_j = x_j.view(-1, self.heads, self.out_channels)
         if x_i is None:
@@ -106,7 +108,7 @@ class GATConv(MessagePassing):
         alpha = F.leaky_relu(alpha, self.negative_slope)
         alpha = softmax(alpha, edge_index_i, size_i)
 
-        if self.__save_att__:
+        if store_attention_weights:
             self.__alpha__ = alpha
 
         # Sample attention coefficients stochastically.
@@ -124,14 +126,8 @@ class GATConv(MessagePassing):
             aggr_out = aggr_out + self.bias
         return aggr_out
 
-    @torch.no_grad()
-    def get_attention_weight(self, x, edge_index, size=None):
-        self.__save_att__ = True
-        self(x, edge_index, size)
-        self.__save_att__ = False
-        edge_index, alpha = self.__edge_index__, self.__alpha__
-        self.__edge_index__ = self.__alpha__ = None
-        return edge_index, alpha
+    def get_attention_weights(self):
+        return self.__edge_index__, self.__alpha__
 
     def __repr__(self):
         return '{}({}, {}, heads={})'.format(self.__class__.__name__,

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -56,7 +56,7 @@ class GATConv(MessagePassing):
         self.concat = concat
         self.negative_slope = negative_slope
         self.dropout = dropout
-        self.__edge_index__ = None
+        
         self.__alpha__ = None
 
         self.weight = Parameter(torch.Tensor(in_channels,
@@ -78,7 +78,7 @@ class GATConv(MessagePassing):
         zeros(self.bias)
 
     def forward(self, x, edge_index, size=None,
-                store_attention_weights=False):
+                return_attention_weights=False):
         """"""
         if size is None and torch.is_tensor(x):
             edge_index, _ = remove_self_loops(edge_index)
@@ -91,12 +91,17 @@ class GATConv(MessagePassing):
             x = (None if x[0] is None else torch.matmul(x[0], self.weight),
                  None if x[1] is None else torch.matmul(x[1], self.weight))
 
-        if store_attention_weights:
-            self.__edge_index__ = edge_index
+        out = self.propagate(edge_index, size=size, x=x,
+                             return_attention_weights=return_attention_weights)
 
-        return self.propagate(edge_index, size=size, x=x)
+        if return_attention_weights:
+            alpha, self.__alpha__ = self.__alpha__, None
+            return out, (alpha, edge_index)
+        else:
+            return out
 
-    def message(self, edge_index_i, x_i, x_j, size_i, store_attention_weights):
+    def message(self, edge_index_i, x_i, x_j, size_i,
+                return_attention_weights):
         # Compute attention coefficients.
         x_j = x_j.view(-1, self.heads, self.out_channels)
         if x_i is None:
@@ -108,7 +113,7 @@ class GATConv(MessagePassing):
         alpha = F.leaky_relu(alpha, self.negative_slope)
         alpha = softmax(alpha, edge_index_i, size_i)
 
-        if store_attention_weights:
+        if return_attention_weights:
             self.__alpha__ = alpha
 
         # Sample attention coefficients stochastically.
@@ -125,9 +130,6 @@ class GATConv(MessagePassing):
         if self.bias is not None:
             aggr_out = aggr_out + self.bias
         return aggr_out
-
-    def get_attention_weights(self):
-        return self.__edge_index__, self.__alpha__
 
     def __repr__(self):
         return '{}({}, {}, heads={})'.format(self.__class__.__name__,


### PR DESCRIPTION
This is what I was thinking about. I believe it saves an unnecessary forward pass if someone wants both the output and the attention weights.

If there is a problem with storing these values inside GATConv to return later, I can change forward to return `x, edge_index, alpha` like commented on #1227. Although this will still store the state of alpha, as was done previously.