### PR TITLE
request to add parameter 'desired_max_num_nodes'

### DIFF
--- a/test/utils/test_to_dense_adj.py
+++ b/test/utils/test_to_dense_adj.py
@@ -11,16 +11,34 @@ def test_to_dense_adj():
     assert adj[0].tolist() == [[1, 1, 0], [1, 0, 0], [0, 0, 0]]
     assert adj[1].tolist() == [[0, 1, 0], [0, 0, 1], [1, 0, 0]]
 
+    adj = to_dense_adj(edge_index, batch, max_num_nodes=5)
+    assert adj.size() == (2, 5, 5)
+    assert adj[0][:3, :3].tolist() == [[1, 1, 0], [1, 0, 0], [0, 0, 0]]
+    assert adj[1][:3, :3].tolist() == [[0, 1, 0], [0, 0, 1], [1, 0, 0]]
+
     edge_attr = torch.Tensor([1, 2, 3, 4, 5, 6])
     adj = to_dense_adj(edge_index, batch, edge_attr)
     assert adj.size() == (2, 3, 3)
     assert adj[0].tolist() == [[1, 2, 0], [3, 0, 0], [0, 0, 0]]
     assert adj[1].tolist() == [[0, 4, 0], [0, 0, 5], [6, 0, 0]]
 
+    adj = to_dense_adj(edge_index, batch, edge_attr, max_num_nodes=5)
+    assert adj.size() == (2, 5, 5)
+    assert adj[0][:3, :3].tolist() == [[1, 2, 0], [3, 0, 0], [0, 0, 0]]
+    assert adj[1][:3, :3].tolist() == [[0, 4, 0], [0, 0, 5], [6, 0, 0]]
+
     edge_attr = edge_attr.view(-1, 1)
     adj = to_dense_adj(edge_index, batch, edge_attr)
     assert adj.size() == (2, 3, 3, 1)
 
+    edge_attr = edge_attr.view(-1, 1)
+    adj = to_dense_adj(edge_index, batch, edge_attr, max_num_nodes=5)
+    assert adj.size() == (2, 5, 5, 1)
+
     adj = to_dense_adj(edge_index)
     assert adj.size() == (1, 5, 5)
+    assert adj[0].nonzero().t().tolist() == edge_index.tolist()
+
+    adj = to_dense_adj(edge_index, max_num_nodes=10)
+    assert adj.size() == (1, 10, 10)
     assert adj[0].nonzero().t().tolist() == edge_index.tolist()

--- a/test/utils/test_to_dense_batch.py
+++ b/test/utils/test_to_dense_batch.py
@@ -16,7 +16,17 @@ def test_to_dense_batch():
     assert out.tolist() == expected
     assert mask.tolist() == [[1, 1, 0], [1, 0, 0], [1, 1, 1]]
 
+    out, mask = to_dense_batch(x, batch, max_num_nodes=5)
+    assert out.size() == (3, 5, 2)
+    assert out[:, :3].tolist() == expected
+    assert mask.tolist() == [[1, 1, 0, 0, 0], [1, 0, 0, 0, 0], [1, 1, 1, 0, 0]]
+
     out, mask = to_dense_batch(x)
     assert out.size() == (1, 6, 2)
     assert out[0].tolist() == x.tolist()
     assert mask.tolist() == [[1, 1, 1, 1, 1, 1]]
+
+    out, mask = to_dense_batch(x, max_num_nodes=10)
+    assert out.size() == (1, 10, 2)
+    assert out[0, :6].tolist() == x.tolist()
+    assert mask.tolist() == [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0]]

--- a/torch_geometric/utils/to_dense_adj.py
+++ b/torch_geometric/utils/to_dense_adj.py
@@ -2,7 +2,7 @@ import torch
 from torch_scatter import scatter_add
 
 
-def to_dense_adj(edge_index, batch=None, edge_attr=None, desired_max_num_nodes=0):
+def to_dense_adj(edge_index, batch=None, edge_attr=None, max_num_nodes=None):
     r"""Converts batched sparse adjacency matrices given by edge indices and
     edge attributes to a single dense batched adjacency matrix.
 
@@ -13,16 +13,21 @@ def to_dense_adj(edge_index, batch=None, edge_attr=None, desired_max_num_nodes=0
             node to a specific example. (default: :obj:`None`)
         edge_attr (Tensor, optional): Edge weights or multi-dimensional edge
             features. (default: :obj:`None`)
+        max_num_nodes (int, optional): The size of the output node dimension.
+            (default: :obj:`None`)
 
     :rtype: :class:`Tensor`
     """
     if batch is None:
         batch = edge_index.new_zeros(edge_index.max().item() + 1)
+
     batch_size = batch[-1].item() + 1
     one = batch.new_ones(batch.size(0))
     num_nodes = scatter_add(one, batch, dim=0, dim_size=batch_size)
     cum_nodes = torch.cat([batch.new_zeros(1), num_nodes.cumsum(dim=0)])
-    max_num_nodes = max(num_nodes.max().item(), desired_max_num_nodes)
+
+    if max_num_nodes is None:
+        max_num_nodes = num_nodes.max().item()
 
     size = [batch_size, max_num_nodes, max_num_nodes]
     size = size if edge_attr is None else size + list(edge_attr.size())[1:]

--- a/torch_geometric/utils/to_dense_adj.py
+++ b/torch_geometric/utils/to_dense_adj.py
@@ -2,7 +2,7 @@ import torch
 from torch_scatter import scatter_add
 
 
-def to_dense_adj(edge_index, batch=None, edge_attr=None):
+def to_dense_adj(edge_index, batch=None, edge_attr=None, desired_max_num_nodes=0):
     r"""Converts batched sparse adjacency matrices given by edge indices and
     edge attributes to a single dense batched adjacency matrix.
 
@@ -22,7 +22,7 @@ def to_dense_adj(edge_index, batch=None, edge_attr=None):
     one = batch.new_ones(batch.size(0))
     num_nodes = scatter_add(one, batch, dim=0, dim_size=batch_size)
     cum_nodes = torch.cat([batch.new_zeros(1), num_nodes.cumsum(dim=0)])
-    max_num_nodes = num_nodes.max().item()
+    max_num_nodes = max(num_nodes.max().item(), desired_max_num_nodes)
 
     size = [batch_size, max_num_nodes, max_num_nodes]
     size = size if edge_attr is None else size + list(edge_attr.size())[1:]

--- a/torch_geometric/utils/to_dense_batch.py
+++ b/torch_geometric/utils/to_dense_batch.py
@@ -2,7 +2,7 @@ import torch
 from torch_scatter import scatter_add
 
 
-def to_dense_batch(x, batch=None, fill_value=0, desired_max_num_nodes=0):
+def to_dense_batch(x, batch=None, fill_value=0, max_num_nodes=None):
     r"""Given a sparse batch of node features
     :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}` (with
     :math:`N_i` indicating the number of nodes in graph :math:`i`), creates a
@@ -20,18 +20,25 @@ def to_dense_batch(x, batch=None, fill_value=0, desired_max_num_nodes=0):
             node to a specific example. (default: :obj:`None`)
         fill_value (float, optional): The value for invalid entries in the
             resulting dense output tensor. (default: :obj:`0`)
+        max_num_nodes (int, optional): The size of the output node dimension.
+            (default: :obj:`None`)
 
     :rtype: (:class:`Tensor`, :class:`BoolTensor`)
     """
-    if batch is None:
+    if batch is None and max_num_nodes is None:
         mask = torch.ones(1, x.size(0), dtype=torch.bool, device=x.device)
         return x.unsqueeze(0), mask
+
+    if batch is None:
+        batch = x.new_zeros(x.size(0), dtype=torch.long)
 
     batch_size = batch[-1].item() + 1
     num_nodes = scatter_add(batch.new_ones(x.size(0)), batch, dim=0,
                             dim_size=batch_size)
     cum_nodes = torch.cat([batch.new_zeros(1), num_nodes.cumsum(dim=0)])
-    max_num_nodes = max(num_nodes.max().item(), desired_max_num_nodes)
+
+    if max_num_nodes is None:
+        max_num_nodes = num_nodes.max().item()
 
     idx = torch.arange(batch.size(0), dtype=torch.long, device=x.device)
     idx = (idx - cum_nodes[batch]) + (batch * max_num_nodes)

--- a/torch_geometric/utils/to_dense_batch.py
+++ b/torch_geometric/utils/to_dense_batch.py
@@ -2,7 +2,7 @@ import torch
 from torch_scatter import scatter_add
 
 
-def to_dense_batch(x, batch=None, fill_value=0):
+def to_dense_batch(x, batch=None, fill_value=0, desired_max_num_nodes=0):
     r"""Given a sparse batch of node features
     :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times F}` (with
     :math:`N_i` indicating the number of nodes in graph :math:`i`), creates a
@@ -31,7 +31,7 @@ def to_dense_batch(x, batch=None, fill_value=0):
     num_nodes = scatter_add(batch.new_ones(x.size(0)), batch, dim=0,
                             dim_size=batch_size)
     cum_nodes = torch.cat([batch.new_zeros(1), num_nodes.cumsum(dim=0)])
-    max_num_nodes = num_nodes.max().item()
+    max_num_nodes = max(num_nodes.max().item(), desired_max_num_nodes)
 
     idx = torch.arange(batch.size(0), dtype=torch.long, device=x.device)
     idx = (idx - cum_nodes[batch]) + (batch * max_num_nodes)


### PR DESCRIPTION
For functions 'to_dense_adj' and 'to_dense_batch' in utils package, sometimes it requires to extend the dimension of feature matrix or adjacency matrix to 'desired max number of nodes' but not equal to the max number of nodes in a batch.