### PR TITLE
Fix GDC with self-loops

### DIFF
--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -217,6 +217,7 @@ class GDC(object):
             edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
                                                      fill_value=1,
                                                      num_nodes=num_nodes)
+            edge_index, edge_weight = coalesce(edge_index, edge_weight, num_nodes, num_nodes)
             mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
             diff_matrix = kwargs['alpha'] * torch.inverse(mat)
 
@@ -226,6 +227,7 @@ class GDC(object):
                                                      fill_value=-1,
                                                      num_nodes=num_nodes)
             edge_weight = kwargs['t'] * edge_weight
+            edge_index, edge_weight = coalesce(edge_index, edge_weight, num_nodes, num_nodes)
             mat = to_dense_adj(edge_index, edge_attr=edge_weight).squeeze()
             undirected = is_undirected(edge_index, edge_weight, num_nodes)
             diff_matrix = self.__expm__(mat, undirected)


### PR DESCRIPTION
to_dense_adj does not consider duplicate entries in edge_index. We therefore need to coalesce before calling it.