### PR TITLE
On the computation of KL divergence for graph VAE

### DIFF
--- a/examples/argva_node_clustering.py
+++ b/examples/argva_node_clustering.py
@@ -26,11 +26,11 @@ class Encoder(torch.nn.Module):
         super(Encoder, self).__init__()
         self.conv1 = GCNConv(in_channels, hidden_channels, cached=True)
         self.conv_mu = GCNConv(hidden_channels, out_channels, cached=True)
-        self.conv_logvar = GCNConv(hidden_channels, out_channels, cached=True)
+        self.conv_logstd = GCNConv(hidden_channels, out_channels, cached=True)
 
     def forward(self, x, edge_index):
         x = F.relu(self.conv1(x, edge_index))
-        return self.conv_mu(x, edge_index), self.conv_logvar(x, edge_index)
+        return self.conv_mu(x, edge_index), self.conv_logstd(x, edge_index)
 
 
 class Discriminator(torch.nn.Module):

--- a/examples/autoencoder.py
+++ b/examples/autoencoder.py
@@ -32,7 +32,7 @@ class Encoder(torch.nn.Module):
             self.conv2 = GCNConv(2 * out_channels, out_channels, cached=True)
         elif args.model in ['VGAE']:
             self.conv_mu = GCNConv(2 * out_channels, out_channels, cached=True)
-            self.conv_logvar = GCNConv(2 * out_channels, out_channels,
+            self.conv_logstd = GCNConv(2 * out_channels, out_channels,
                                        cached=True)
 
     def forward(self, x, edge_index):
@@ -40,7 +40,7 @@ class Encoder(torch.nn.Module):
         if args.model in ['GAE']:
             return self.conv2(x, edge_index)
         elif args.model in ['VGAE']:
-            return self.conv_mu(x, edge_index), self.conv_logvar(x, edge_index)
+            return self.conv_mu(x, edge_index), self.conv_logstd(x, edge_index)
 
 
 channels = 16

--- a/test/nn/models/test_autoencoder.py
+++ b/test/nn/models/test_autoencoder.py
@@ -63,7 +63,7 @@ def test_argva():
 
     x = torch.Tensor([[1, -1], [1, 2], [2, 1]])
     model.encode(x)
-    model.reparametrize(model.__mu__, model.__logvar__)
+    model.reparametrize(model.__mu__, model.__logstd__)
     assert model.kl_loss().item() > 0
 
 

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -6,7 +6,7 @@ from torch_geometric.utils import (negative_sampling, remove_self_loops,
 from ..inits import reset
 
 EPS = 1e-15
-MAX_LOGVAR = 10
+MAX_LOGSTD = 10
 
 
 class InnerProductDecoder(torch.nn.Module):
@@ -141,36 +141,36 @@ class VGAE(GAE):
     def __init__(self, encoder, decoder=None):
         super(VGAE, self).__init__(encoder, decoder)
 
-    def reparametrize(self, mu, logvar):
+    def reparametrize(self, mu, logstd):
         if self.training:
-            return mu + torch.randn_like(logvar) * torch.exp(logvar)
+            return mu + torch.randn_like(logstd) * torch.exp(logstd)
         else:
             return mu
 
     def encode(self, *args, **kwargs):
         """"""
-        self.__mu__, self.__logvar__ = self.encoder(*args, **kwargs)
-        self.__logvar__ = self.__logvar__.clamp(max=MAX_LOGVAR)
-        z = self.reparametrize(self.__mu__, self.__logvar__)
+        self.__mu__, self.__logstd__ = self.encoder(*args, **kwargs)
+        self.__logstd__ = self.__logstd__.clamp(max=MAX_LOGSTD)
+        z = self.reparametrize(self.__mu__, self.__logstd__)
         return z
 
-    def kl_loss(self, mu=None, logvar=None):
+    def kl_loss(self, mu=None, logstd=None):
         r"""Computes the KL loss, either for the passed arguments :obj:`mu`
-        and :obj:`logvar`, or based on latent variables from last encoding.
+        and :obj:`logstd`, or based on latent variables from last encoding.
 
         Args:
             mu (Tensor, optional): The latent space for :math:`\mu`. If set to
                 :obj:`None`, uses the last computation of :math:`mu`.
                 (default: :obj:`None`)
-            logvar (Tensor, optional): The latent space for
-                :math:`\log\sigma^2`.  If set to :obj:`None`, uses the last
+            logstd (Tensor, optional): The latent space for
+                :math:`\log\sigma`.  If set to :obj:`None`, uses the last
                 computation of :math:`\log\sigma^2`.(default: :obj:`None`)
         """
         mu = self.__mu__ if mu is None else mu
-        logvar = self.__logvar__ if logvar is None else logvar.clamp(
-            max=MAX_LOGVAR)
+        logstd = self.__logstd__ if logstd is None else logstd.clamp(
+            max=MAX_LOGSTD)
         return -0.5 * torch.mean(
-            torch.sum(1 + logvar - mu**2 - logvar.exp(), dim=1))
+            torch.sum(1 + 2*logstd - mu**2 - logstd.exp()**2, dim=1))
 
 
 class ARGA(GAE):
@@ -243,15 +243,15 @@ class ARGVA(ARGA):
         return self.VGAE.__mu__
 
     @property
-    def __logvar__(self):
-        return self.VGAE.__logvar__
+    def __logstd__(self):
+        return self.VGAE.__logstd__
 
-    def reparametrize(self, mu, logvar):
-        return self.VGAE.reparametrize(mu, logvar)
+    def reparametrize(self, mu, logstd):
+        return self.VGAE.reparametrize(mu, logstd)
 
     def encode(self, *args, **kwargs):
         """"""
         return self.VGAE.encode(*args, **kwargs)
 
-    def kl_loss(self, mu=None, logvar=None):
-        return self.VGAE.kl_loss(mu, logvar)
+    def kl_loss(self, mu=None, logstd=None):
+        return self.VGAE.kl_loss(mu, logstd)


### PR DESCRIPTION
Dear @rusty1s, 

First of all, I would like to congratulate you and your collaborators for this amazing work.

I recently noticed that your computation of the Kullback-Leibler divergence for the ELBO objective of graph VAE models slightly differs from Thomas Kipf's [original TF implementation](https://github.com/tkipf/gae/blob/master/gae/optimizer.py). More precisely, a square and a x2 terms are missing:
- Current KL: `-0.5 * torch.mean(torch.sum(1 + logvar - mu**2 - logvar.exp(), dim=1))`
- Pytorch equivalent of original KL:`-0.5 * torch.mean(torch.sum(1 + 2*logvar - mu**2 - logvar.exp()**2, dim=1))`

I think that the original version is the correct one (see e.g. [here](https://stats.stackexchange.com/questions/7440/kl-divergence-between-two-univariate-gaussians) for the computation in 1 dimension ; taking mu_2 = 0 and sigma_2 = 1 in the final formula), and I therefore open this PR for an update.

Besides, I also propose to replace the `logvar` naming by `logstd`, as in the original implementation. Such notation would be more consistent with the mathematical terms actually used in the KL (the first one should be the log of the standard deviation ; the second one - with the square - is the variance). It would also be more consistent w.r.t. the "reparameterization trick" (see line 146 of `torch_geometric/nn/models/autoencoder.py`) where the N(0,I) random samples need to be multiplied by the standard deviation, not by the variance. I therefore updated all occurences of `logvar` by `logstd` in the project.

Best,

Guillaume