### PR TITLE
Static Graph Tests

### DIFF
--- a/test/nn/conv/test_gcn_conv.py
+++ b/test/nn/conv/test_gcn_conv.py
@@ -50,7 +50,10 @@ def test_gcn_conv_with_sparse_input_feature():
 def test_static_gcn_conv():
     x = torch.randn(3, 4, 16)
     edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    row, col = edge_index
+    adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
 
     conv = GCNConv(16, 32)
     out = conv(x, edge_index)
     assert out.size() == (3, 4, 32)
+    assert torch.allclose(conv(x, adj.t()), out, atol=1e-6)

--- a/test/nn/conv/test_mf_conv.py
+++ b/test/nn/conv/test_mf_conv.py
@@ -11,13 +11,3 @@ def test_mf_conv():
     conv = MFConv(in_channels, out_channels)
     assert conv.__repr__() == 'MFConv(16, 32)'
     assert conv(x, edge_index).size() == (num_nodes, out_channels)
-
-
-def test_static_mf_conv():
-    in_channels, out_channels = (16, 32)
-    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
-    num_nodes = edge_index.max().item() + 1
-    x = torch.randn((4, num_nodes, in_channels))
-
-    conv = MFConv(in_channels, out_channels, node_dim=1)
-    assert conv(x, edge_index).size() == (4, num_nodes, out_channels)

--- a/test/nn/conv/test_sage_conv.py
+++ b/test/nn/conv/test_sage_conv.py
@@ -47,3 +47,15 @@ def test_sage_conv():
     jit = torch.jit.script(conv.jittable(t))
     assert jit((x1, x2), adj.t()).tolist() == out1.tolist()
     assert jit((x1, None), adj.t()).tolist() == out2.tolist()
+
+
+def test_static_sage_conv():
+    x = torch.randn(3, 4, 16)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    row, col = edge_index
+    adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
+
+    conv = SAGEConv(16, 32)
+    out = conv(x, edge_index)
+    assert out.size() == (3, 4, 32)
+    assert conv(x, adj.t()).tolist() == out.tolist()


### PR DESCRIPTION
**Test static graph support for GNN operators:**

- [ ] AGNNConv
- [ ] APPNP
- [ ] ARMAConv
- [ ] CGConv
- [ ] ChebConv
- [ ] DNAConv
- [ ] EdgeConv 
- [ ] DynamicEdgeConv
- [ ] FeaStConv
- [ ] GATConv 
- [ ] GatedGraphConv
- [x] GCNConv
- [ ] GINConv
- [ ] GINEConv
- [ ] GMMConv
- [ ] GraphConv
- [ ] GravNetConv
- [ ] HypergraphConv - NB: needs overall refactoring
- [ ] NNConv
- [ ] MFConv
- [ ] PointConv
- [ ] PPFConv
- [ ] RGCNConv
- [x] SAGEConv
- [ ] SGConv
- [ ] SignedConv
- [ ] SplineConv
- [ ] TAGConv
- [ ] XConv