### PR TITLE
Make sure all Linear layers respect bias argument

### DIFF
--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -44,7 +44,7 @@ class MFConv(MessagePassing):
             in_channels = (in_channels, in_channels)
 
         self.lins_l = ModuleList([
-            Linear(in_channels[0], out_channels, bias=False)
+            Linear(in_channels[0], out_channels, bias=bias)
             for _ in range(max_degree + 1)
         ])
 


### PR DESCRIPTION
Hi @rusty1s, 

When I made the #1248 PR, I had originally proposed both root and neighbor transforms have an additive bias. I'm not sure if this was intentionally hardcoded as `False` but I think it's more intuitive if both transforms respect the bias argument.

Thanks!