### PR TITLE
train_test_split_edges uses single random source

### DIFF
--- a/torch_geometric/utils/train_test_split_edges.py
+++ b/torch_geometric/utils/train_test_split_edges.py
@@ -1,5 +1,4 @@
 import math
-import random
 import torch
 from torch_geometric.utils import to_undirected
 
@@ -53,10 +52,7 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
     neg_adj_mask[row, col] = 0
 
     neg_row, neg_col = neg_adj_mask.nonzero(as_tuple=False).t()
-    perm = random.sample(range(neg_row.size(0)), min(n_v + n_t,
-                                                     neg_row.size(0)))
-    perm = torch.tensor(perm)
-    perm = perm.to(torch.long)
+    perm = torch.randperm(neg_row.size(0))[:n_v + n_t]
     neg_row, neg_col = neg_row[perm], neg_col[perm]
 
     neg_adj_mask[neg_row, neg_col] = 0


### PR DESCRIPTION
current implementation of train_test_split_edges uses multiple randomness sources which harden the ability to reproduce experiment results. Given the name "torch_geometric" one would expect having set torch randomness state, that the produced split would be the same -> but this is not the case!

As such I suggest using only torch.randperm as the randomness source for the function.


Ido