### PR TITLE
change in-place "mul_" to "mul"

### DIFF
--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -5,7 +5,7 @@ import torch
 from torch import Tensor
 from torch.nn import Parameter
 from torch_scatter import scatter_add
-from torch_sparse import SparseTensor, matmul, fill_diag, sum, mul_
+from torch_sparse import SparseTensor, matmul, fill_diag, sum, mul
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.utils import add_remaining_self_loops
 from torch_geometric.utils.num_nodes import maybe_num_nodes
@@ -41,8 +41,8 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
         deg = sum(adj_t, dim=1)
         deg_inv_sqrt = deg.pow_(-0.5)
         deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0.)
-        adj_t = mul_(adj_t, deg_inv_sqrt.view(-1, 1))
-        adj_t = mul_(adj_t, deg_inv_sqrt.view(1, -1))
+        adj_t = mul(adj_t, deg_inv_sqrt.view(-1, 1))
+        adj_t = mul(adj_t, deg_inv_sqrt.view(1, -1))
         return adj_t
 
     else:


### PR DESCRIPTION
Bug fix: Avoid in-place operations that could change the argument `edge_index`.

When `edge_index` is a `SparseTensor`, if both `if`-statements' conditions are not satisfied, (i.e, when `edge_index` has value, and `add_self_loops=False`, because of the in-place operation `mul_`, the function argument `edge_index` will change after each execution of `gcn_norm`, which is an undesired behavior.

The following example describes a scenario when current `gcn_norm` gets this unexpected side-effect:
```python
import torch
import torch_geometric
import torch_geometric.transforms as T
from ogb.nodeproppred import PygNodePropPredDataset
from torch_geometric.nn.conv.gcn_conv import gcn_norm

dataset = PygNodePropPredDataset(name='ogbn-arxiv', transform=T.ToSparseTensor())
data = dataset[0]
data.adj_t = data.adj_t.to_symmetric()
data.adj_t.fill_value_(1.) 

edge_index = gcn_norm(data.adj_t, edge_weight=None, num_nodes=data.num_nodes, add_self_loops=False, dtype=data.x.dtype)
print(edge_index, data.adj_t)
print(id(data.adj_t) == id(edge_index))
```

The output is:
```shell
SparseTensor(row=tensor([     0,      0,      0,  ..., 169341, 169342, 169342]),
             col=tensor([   411,    640,   1162,  ..., 163274,  27824, 158981]),
             val=tensor([0.0338, 0.0054, 0.0089,  ..., 0.0095, 0.0554, 0.1104]),
             size=(169343, 169343), nnz=2315598, density=0.01%)
SparseTensor(row=tensor([     0,      0,      0,  ..., 169341, 169342, 169342]),
             col=tensor([   411,    640,   1162,  ..., 163274,  27824, 158981]),
             val=tensor([0.0338, 0.0054, 0.0089,  ..., 0.0095, 0.0554, 0.1104]),
             size=(169343, 169343), nnz=2315598, density=0.01%)
True
```
As above, you can see `data.adj_t` is also modified. Check also [this colab](https://colab.research.google.com/drive/1A66inKb6iiZQVdkS8fJrVEfLTQjzDvC_?usp=sharing). To fix this, simply change the `mul_` to `mul` is enough.