### PR TITLE
Fixed AttributeError due to line 139

### DIFF
--- a/torch_geometric/nn/conv/gen_conv.py
+++ b/torch_geometric/nn/conv/gen_conv.py
@@ -151,7 +151,7 @@ class GENConv(MessagePassing):
         out = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=size)
 
         if self.msg_norm is not None:
-            out = self.msg_norm(x, out)
+            out = self.msg_norm(x[0], out)
 
         x_r = x[1]
         if x_r is not None:


### PR DESCRIPTION
~/.conda/envs/rdclone/lib/python3.6/site-packages/torch_geometric/nn/conv/gen_conv.py in forward(self, x, edge_index, edge_attr, size)
    152 
    153         if self.msg_norm is not None:
--> 154             out = self.msg_norm(x, out)
    155 
    156         x_r = x[1]

~/.conda/envs/rdclone/lib/python3.6/site-packages/torch/nn/modules/module.py in __call__(self, *input, **kwargs)
    548             result = self._slow_forward(*input, **kwargs)
    549         else:
--> 550             result = self.forward(*input, **kwargs)
    551         for hook in self._forward_hooks.values():
    552             hook_result = hook(self, input, result)

~/.conda/envs/rdclone/lib/python3.6/site-packages/torch_geometric/nn/norm/msg_norm.py in forward(self, x, msg, p)
     32         """"""
     33         msg = F.normalize(msg, p=p, dim=-1)
---> 34         x_norm = x.norm(p=p, dim=-1, keepdim=True)
     35         return msg * x_norm * self.scale
     36 

AttributeError: 'tuple' object has no attribute 'norm'