### PR TITLE
Fix gnn_explainer bug

### DIFF
--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -123,7 +123,7 @@ class GNNExplainer(torch.nn.Module):
         loss = loss + self.coeffs['edge_ent'] * ent.mean()
 
         m = self.node_feat_mask.sigmoid()
-        loss = loss + self.coeffs['node_feat_size'] * m.sum()
+        loss = loss + self.coeffs['node_feat_size'] * m.mean()
         ent = -m * torch.log(m + EPS) - (1 - m) * torch.log(1 - m + EPS)
         loss = loss + self.coeffs['node_feat_ent'] * ent.mean()
 

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -44,7 +44,9 @@ class GNNExplainer(torch.nn.Module):
 
     coeffs = {
         'edge_size': 0.005,
+        'edge_reduction': 'sum',
         'node_feat_size': 1.0,
+        'node_feat_reduction': 'mean',
         'edge_ent': 1.0,
         'node_feat_ent': 0.1,
     }
@@ -118,12 +120,14 @@ class GNNExplainer(torch.nn.Module):
         loss = -log_logits[node_idx, pred_label[node_idx]]
 
         m = self.edge_mask.sigmoid()
-        loss = loss + self.coeffs['edge_size'] * m.sum()
+        edge_reduce = getattr(torch, self.coeffs['edge_reduction'])
+        loss = loss + self.coeffs['edge_size'] * edge_reduce(m)
         ent = -m * torch.log(m + EPS) - (1 - m) * torch.log(1 - m + EPS)
         loss = loss + self.coeffs['edge_ent'] * ent.mean()
 
         m = self.node_feat_mask.sigmoid()
-        loss = loss + self.coeffs['node_feat_size'] * m.mean()
+        node_feat_reduce = getattr(torch, self.coeffs['node_feat_reduction'])
+        loss = loss + self.coeffs['node_feat_size'] * node_feat_reduce(m)
         ent = -m * torch.log(m + EPS) - (1 - m) * torch.log(1 - m + EPS)
         loss = loss + self.coeffs['node_feat_ent'] * ent.mean()
 


### PR DESCRIPTION
It seems ```mean``` should be applied to feature mask here. The code below is from the original repo of [gnnexplainer](https://github.com/RexYing/gnn-model-explainer/blob/master/explainer/explain.py#L763).
```        feat_size_loss = self.coeffs["feat_size"] * torch.mean(feat_mask)```

If ```sum``` is used, this loss term becomes very large compared to other loss terms. I use heatmap to visualize the output ```node_feat_mask```, the importance of features are indistinguishable. After it is changed to ```mean```, important features could be identified.