### PR TITLE
Change installation instructions to remove `$` for easier copy paste.

### DIFF
--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -33,32 +33,32 @@ We provide pip wheels for all major OS/PyTorch/CUDA combinations:
 
     .. code-block:: none
 
-         $ pip install torch-scatter==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
-         $ pip install torch-sparse==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
-         $ pip install torch-cluster==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
-         $ pip install torch-spline-conv==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
-         $ pip install torch-geometric
+         pip install torch-scatter==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
+         pip install torch-sparse==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
+         pip install torch-cluster==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
+         pip install torch-spline-conv==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-${TORCH}.html
+         pip install torch-geometric
 
     where :obj:`${CUDA}` and :obj:`${TORCH}` should be replaced by your specific CUDA version (:obj:`cpu`, :obj:`cu92`, :obj:`cu101`, :obj:`cu102`) and PyTorch version (:obj:`1.4.0`, :obj:`1.5.0`, :obj:`1.6.0`), respectively.
     For example, for PyTorch 1.5.0/1.5.1 and CUDA 10.2, type:
 
     .. code-block:: none
 
-         $ pip install torch-scatter==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-         $ pip install torch-sparse==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-         $ pip install torch-cluster==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-         $ pip install torch-spline-conv==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-         $ pip install torch-geometric
+         pip install torch-scatter==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+         pip install torch-sparse==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+         pip install torch-cluster==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+         pip install torch-spline-conv==latest+cu102 -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+         pip install torch-geometric
 
     For PyTorch 1.6.0 and CUDA 10.1, type:
 
     .. code-block:: none
 
-         $ pip install torch-scatter==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
-         $ pip install torch-sparse==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
-         $ pip install torch-cluster==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
-         $ pip install torch-spline-conv==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
-         $ pip install torch-geometric
+         pip install torch-scatter==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
+         pip install torch-sparse==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
+         pip install torch-cluster==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
+         pip install torch-spline-conv==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
+         pip install torch-geometric
 
 Installation from Source
 ------------------------

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -119,11 +119,11 @@ In case a specific version is not supported by `our wheels <https://pytorch-geom
 
     .. code-block:: none
 
-      $ pip install torch-scatter
-      $ pip install torch-sparse
-      $ pip install torch-cluster
-      $ pip install torch-spline-conv
-      $ pip install torch-geometric
+      pip install torch-scatter
+      pip install torch-sparse
+      pip install torch-cluster
+      pip install torch-spline-conv
+      pip install torch-geometric
 
 
 In rare cases, CUDA or Python path problems can prevent a successful installation.


### PR DESCRIPTION
I only removed them from the big blocks of installation instructions.