### PR TITLE
Fix integer division of tensors

### DIFF
--- a/torch_geometric/datasets/gdelt.py
+++ b/torch_geometric/datasets/gdelt.py
@@ -64,7 +64,7 @@ class GDELT(EventDataset):
         events = []
         for path in self.raw_paths:
             data = read_txt_array(path, sep='\t', end=4, dtype=torch.long)
-            data[:, 3] = data[:, 3] / 15
+            data[:, 3] = data[:, 3] // 15
             events += [data]
         return torch.cat(events, dim=0)
 

--- a/torch_geometric/datasets/icews.py
+++ b/torch_geometric/datasets/icews.py
@@ -96,7 +96,7 @@ class ICEWS18(EventDataset):
         events = []
         for path in self.raw_paths:
             data = read_txt_array(path, sep='\t', end=4, dtype=torch.long)
-            data[:, 3] = data[:, 3] / 24
+            data[:, 3] = data[:, 3] // 24
             events += [data]
         return torch.cat(events, dim=0)
 


### PR DESCRIPTION
Python 3.8 changes how integer divison of tensors works.  This
patch is necessary to run the RENet example on Colab.