### PR TITLE
Fix typo in total graphs in ZINC subset

### DIFF
--- a/torch_geometric/datasets/zinc.py
+++ b/torch_geometric/datasets/zinc.py
@@ -19,7 +19,7 @@ class ZINC(InMemoryDataset):
     Args:
         root (string): Root directory where the dataset should be saved.
         subset (boolean, optional): If set to :obj:`True`, will only load a
-            subset of the dataset (13,000 molecular graphs), following the
+            subset of the dataset (12,000 molecular graphs), following the
             `"Benchmarking Graph Neural Networks"
             <https://arxiv.org/abs/2003.00982>`_ paper. (default: :obj:`False`)
         split (string, optional): If :obj:`"train"`, loads the training


### PR DESCRIPTION
The ZINC subset used in [Benchmarking GNNs](http://arxiv.org/abs/2003.00982) has 12,000 molecular graphs - 10,000 train/1,000 val/1,000 test.

PR for this minor correction.