### PR TITLE
Change accuracy return type to float

### DIFF
--- a/torch_geometric/utils/metric.py
+++ b/torch_geometric/utils/metric.py
@@ -12,7 +12,7 @@ def accuracy(pred, target):
         pred (Tensor): The predictions.
         target (Tensor): The targets.
 
-    :rtype: int
+    :rtype: float
     """
     return (pred == target).sum().item() / target.numel()
 


### PR DESCRIPTION
While going through the documentation, I noticed that `torch_geometric.utils.accuracy` has wrong return type (`int`).