### PR TITLE
Addition of Inference Block in examples/link_pred.py

### DIFF
--- a/examples/link_pred.py
+++ b/examples/link_pred.py
@@ -4,22 +4,16 @@ import torch
 import torch.nn.functional as F
 from sklearn.metrics import roc_auc_score
 
-from torch_geometric.utils import (negative_sampling, remove_self_loops,
-                                   add_self_loops,dense_to_sparse)
+from torch_geometric.utils import negative_sampling
 from torch_geometric.datasets import Planetoid
 import torch_geometric.transforms as T
-from torch_geometric.nn import GCNConv, ChebConv  # noqa
+from torch_geometric.nn import GCNConv
 from torch_geometric.utils import train_test_split_edges
-from torch_geometric.nn.models.autoencoder import InnerProductDecoder
-
-torch.manual_seed(12345)
 
 dataset = 'Cora'
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset)
 dataset = Planetoid(path, dataset, transform=T.NormalizeFeatures())
 data = dataset[0]
-
-# Train/validation/test
 data.train_mask = data.val_mask = data.test_mask = data.y = None
 data = train_test_split_edges(data)
 
@@ -30,15 +24,19 @@ class Net(torch.nn.Module):
         self.conv1 = GCNConv(dataset.num_features, 128)
         self.conv2 = GCNConv(128, 64)
 
-    def forward(self, pos_edge_index, neg_edge_index):
+    def encode(self):
+        x = self.conv1(data.x, data.train_pos_edge_index)
+        x = x.relu()
+        return self.conv2(x, data.train_pos_edge_index)
 
-        x = F.relu(self.conv1(data.x, data.train_pos_edge_index))
-        x = self.conv2(x, data.train_pos_edge_index)
+    def decode(self, z, pos_edge_index, neg_edge_index):
+        edge_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
+        logits = (z[edge_index[0]] * z[edge_index[1]]).sum(dim=-1)
+        return logits
 
-        total_edge_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
-        x_j = torch.index_select(x, 0, total_edge_index[0])
-        x_i = torch.index_select(x, 0, total_edge_index[1])
-        return x,torch.einsum("ef,ef->e", x_i, x_j)
+    def decode_all(self, z):
+        prob_adj = z @ z.t()
+        return (prob_adj > 0).nonzero(as_tuple=False).t()
 
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -47,34 +45,23 @@ optimizer = torch.optim.Adam(params=model.parameters(), lr=0.01)
 
 
 def get_link_labels(pos_edge_index, neg_edge_index):
-    link_labels = torch.zeros(pos_edge_index.size(1) +
-                              neg_edge_index.size(1)).float().to(device)
+    E = pos_edge_index.size(1) + neg_edge_index.size(1)
+    link_labels = torch.zeros(E, dtype=torch.float, device=device)
     link_labels[:pos_edge_index.size(1)] = 1.
     return link_labels
 
-def create_adj_prob_matrix(Latent_Vector):
-    """Use it while inference to resolve the predicted Links"""
-    prob_adj_matrix = InnerProductDecoder().forward_all(Latent_Vector)
-    edge_indices,confidence_probs = dense_to_sparse(prob_adj_matrix)
-    return edge_indices,confidence_probs
 
 def train():
     model.train()
-    optimizer.zero_grad()
-
-    x, pos_edge_index = data.x, data.train_pos_edge_index
-
-    _edge_index, _ = remove_self_loops(pos_edge_index)
-    pos_edge_index_with_self_loops, _ = add_self_loops(_edge_index,
-                                                       num_nodes=x.size(0))
 
     neg_edge_index = negative_sampling(
-        edge_index=pos_edge_index_with_self_loops, num_nodes=x.size(0),
-        num_neg_samples=pos_edge_index.size(1))
+        edge_index=data.train_pos_edge_index, num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1))
 
-    _,link_logits = model(pos_edge_index, neg_edge_index)
-    link_labels = get_link_labels(pos_edge_index, neg_edge_index)
-
+    optimizer.zero_grad()
+    z = model.encode()
+    link_logits = model.decode(z, data.train_pos_edge_index, neg_edge_index)
+    link_labels = get_link_labels(data.train_pos_edge_index, neg_edge_index)
     loss = F.binary_cross_entropy_with_logits(link_logits, link_labels)
     loss.backward()
     optimizer.step()
@@ -82,30 +69,24 @@ def train():
     return loss
 
 
+@torch.no_grad()
 def test():
     model.eval()
     perfs = []
     for prefix in ["val", "test"]:
-        pos_edge_index, neg_edge_index = [
-            index for _, index in data("{}_pos_edge_index".format(prefix),
-                                       "{}_neg_edge_index".format(prefix))
-        ]
-        _,link_logits = model(pos_edge_index,neg_edge_index)
-        link_probs = torch.sigmoid(link_logits)
+        pos_edge_index = data[f'{prefix}_pos_edge_index']
+        neg_edge_index = data[f'{prefix}_neg_edge_index']
+
+        z = model.encode()
+        link_logits = model.decode(z, pos_edge_index, neg_edge_index)
+        link_probs = link_logits.sigmoid()
         link_labels = get_link_labels(pos_edge_index, neg_edge_index)
-        link_probs = link_probs.detach().cpu().numpy()
-        link_labels = link_labels.detach().cpu().numpy()
-        perfs.append(roc_auc_score(link_labels, link_probs))
+        perfs.append(roc_auc_score(link_labels.cpu(), link_probs.cpu()))
     return perfs
 
-def infer(pos_edge_index,neg_edge_index):
-    """Infering the model"""
-    model.eval()
-    latent,link_logits = model(pos_edge_index,neg_edge_index)
-    pred_edge_index,pred_confidence = create_adj_prob_matrix(latent)
-    return pred_edge_index
+
 best_val_perf = test_perf = 0
-for epoch in range(1, 501):
+for epoch in range(1, 101):
     train_loss = train()
     val_perf, tmp_test_perf = test()
     if val_perf > best_val_perf:
@@ -114,4 +95,5 @@ for epoch in range(1, 501):
     log = 'Epoch: {:03d}, Loss: {:.4f}, Val: {:.4f}, Test: {:.4f}'
     print(log.format(epoch, train_loss, best_val_perf, test_perf))
 
-pred_edge_index = 
+z = model.encode()
+final_edge_index = model.decode_all(z)

--- a/examples/link_pred.py
+++ b/examples/link_pred.py
@@ -54,7 +54,7 @@ def get_link_labels(pos_edge_index, neg_edge_index):
 
 def create_adj_prob_matrix(Latent_Vector):
     """Use it while inference to resolve the predicted Links"""
-    prob_adj_matrix = InnerProductDecoder()(Latent_Vector)
+    prob_adj_matrix = InnerProductDecoder().forward_all(Latent_Vector)
     edge_indices,confidence_probs = dense_to_sparse(prob_adj_matrix)
     return edge_indices,confidence_probs
 


### PR DESCRIPTION
The existing version of examples/link_pred.py doesn't have a proper inference example. Refer #1699, added a inference block with `InnerProductDecoder.forward_all()` to give out a probability adjacency matrix. This would give a cleaner view on usage in inference stage. 