### PR TITLE
Adding batching of arbitrary length paths

### DIFF
--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -5,31 +5,32 @@ from torch_geometric.data import Data, Batch
 
 def test_batch():
     torch_geometric.set_debug(True)
+    # import pdb; pdb.set_trace()
 
     x1 = torch.tensor([1, 2, 3], dtype=torch.float)
     e1 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
-    p1 = [torch.tensor([1, 0, 2]), torch.tensor([0, 2])]
+    p1 = torch.tensor([[1, 0, 2], [0, 2, 1e9]], dtype=torch.long)
     pf1 = [torch.tensor([False]), torch.tensor([True])]
     s1 = '1'
     x2 = torch.tensor([1, 2], dtype=torch.float)
     e2 = torch.tensor([[0, 1], [1, 0]])
-    p2 = [torch.tensor([1, 0])]
+    p2 = torch.tensor([[1, 0]])
     pf2 = [torch.tensor([True])]
     s2 = '2'
 
     data = Batch.from_data_list([
-        Data(x1, e1, s=s1, paths_index=p1, paths_features=pf1),
-        Data(x2, e2, s=s2, paths_index=p2, paths_features=pf2)
+        Data(x1, e1, s=s1, paths=p1, paths_features=pf1),
+        Data(x2, e2, s=s2, paths=p2, paths_features=pf2)
     ])
 
     assert data.__repr__() == (
-        'Batch(batch=[5], edge_index=[2, 6], paths_features=[3], '
-        'paths_index=[3], s=[2], x=[5])')
+        'Batch(batch=[5], edge_index=[2, 6], paths=[3, 3]'
+        ', paths_features=[3], s=[2], x=[5])'
+    )
     assert len(data) == 6
     assert data.x.tolist() == [1, 2, 3, 1, 2]
     assert data.edge_index.tolist() == [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]]
-    assert [p.tolist() for p in data.paths_index] == [[1, 0, 2], [0, 2],
-                                                      [4, 3]]
+    assert data.paths.tolist() == [[1, 0, 2], [0, 2, 5], [4, 3, 5]]
     assert data.s == ['1', '2']
     assert data.batch.tolist() == [0, 0, 0, 1, 1]
     assert data.num_graphs == 2
@@ -39,13 +40,14 @@ def test_batch():
     assert len(data_list[0]) == 5
     assert data_list[0].x.tolist() == [1, 2, 3]
     assert data_list[0].edge_index.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
-    assert [p.tolist() for p in data_list[0].paths_index] == [[1, 0, 2],
-                                                              [0, 2]]
+     #NOTE paths not intended to be used, it preserves `uppading`
+    assert data_list[0].paths.tolist() == [[1, 0, 2], [0, 2, 5]]
     assert data_list[0].s == '1'
     assert len(data_list[1]) == 5
     assert data_list[1].x.tolist() == [1, 2]
     assert data_list[1].edge_index.tolist() == [[0, 1], [1, 0]]
-    assert [p.tolist() for p in data_list[1].paths_index] == [[1, 0]]
+     #NOTE paths not intended to be used, it preserves `uppading`
+    assert data_list[1].paths.tolist() == [[1, 0, 2]]
     assert data_list[1].s == '2'
 
     torch_geometric.set_debug(True)

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -8,31 +8,44 @@ def test_batch():
 
     x1 = torch.tensor([1, 2, 3], dtype=torch.float)
     e1 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    p1 = [torch.tensor([1, 0, 2]), torch.tensor([0, 2])]
+    pf1 = [torch.tensor([False]), torch.tensor([True])]
     s1 = '1'
     x2 = torch.tensor([1, 2], dtype=torch.float)
     e2 = torch.tensor([[0, 1], [1, 0]])
+    p2 = [torch.tensor([1, 0])]
+    pf2 = [torch.tensor([True])]
     s2 = '2'
 
-    data = Batch.from_data_list([Data(x1, e1, s=s1), Data(x2, e2, s=s2)])
+    data = Batch.from_data_list([
+        Data(x1, e1, s=s1, paths_index=p1, paths_features=pf1),
+        Data(x2, e2, s=s2, paths_index=p2, paths_features=pf2)
+    ])
 
     assert data.__repr__() == (
-        'Batch(batch=[5], edge_index=[2, 6], s=[2], x=[5])')
-    assert len(data) == 4
+        'Batch(batch=[5], edge_index=[2, 6], paths_features=[3], '
+        'paths_index=[3], s=[2], x=[5])')
+    assert len(data) == 6
     assert data.x.tolist() == [1, 2, 3, 1, 2]
     assert data.edge_index.tolist() == [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]]
+    assert [p.tolist() for p in data.paths_index] == [[1, 0, 2], [0, 2],
+                                                      [4, 3]]
     assert data.s == ['1', '2']
     assert data.batch.tolist() == [0, 0, 0, 1, 1]
     assert data.num_graphs == 2
 
     data_list = data.to_data_list()
     assert len(data_list) == 2
-    assert len(data_list[0]) == 3
+    assert len(data_list[0]) == 5
     assert data_list[0].x.tolist() == [1, 2, 3]
     assert data_list[0].edge_index.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
+    assert [p.tolist() for p in data_list[0].paths_index] == [[1, 0, 2],
+                                                              [0, 2]]
     assert data_list[0].s == '1'
-    assert len(data_list[1]) == 3
+    assert len(data_list[1]) == 5
     assert data_list[1].x.tolist() == [1, 2]
     assert data_list[1].edge_index.tolist() == [[0, 1], [1, 0]]
+    assert [p.tolist() for p in data_list[1].paths_index] == [[1, 0]]
     assert data_list[1].s == '2'
 
     torch_geometric.set_debug(True)

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -25,8 +25,7 @@ def test_batch():
 
     assert data.__repr__() == (
         'Batch(batch=[5], edge_index=[2, 6], paths=[3, 3]'
-        ', paths_features=[3], s=[2], x=[5])'
-    )
+        ', paths_features=[3], s=[2], x=[5])')
     assert len(data) == 6
     assert data.x.tolist() == [1, 2, 3, 1, 2]
     assert data.edge_index.tolist() == [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]]
@@ -40,13 +39,13 @@ def test_batch():
     assert len(data_list[0]) == 5
     assert data_list[0].x.tolist() == [1, 2, 3]
     assert data_list[0].edge_index.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
-     #NOTE paths not intended to be used, it preserves `uppading`
+    #NOTE paths not intended to be used, it preserves `uppading`
     assert data_list[0].paths.tolist() == [[1, 0, 2], [0, 2, 5]]
     assert data_list[0].s == '1'
     assert len(data_list[1]) == 5
     assert data_list[1].x.tolist() == [1, 2]
     assert data_list[1].edge_index.tolist() == [[0, 1], [1, 0]]
-     #NOTE paths not intended to be used, it preserves `uppading`
+    #NOTE paths not intended to be used, it preserves `uppading`
     assert data_list[1].paths.tolist() == [[1, 0, 2]]
     assert data_list[1].s == '2'
 

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -149,11 +149,14 @@ class Batch(Data):
 
                     nodes_in_batch = len(batch.batch)
                     for i, p in enumerate(batch[key]):
-                        batch[key][i][batch[key][i] >= nodes_in_batch] = nodes_in_batch
+                        batch[key][i][
+                            batch[key][i] >= nodes_in_batch] = nodes_in_batch
                         if p.shape[1] == max_len:
                             continue
-                        filler = torch.full((p.shape[0], max_len-p.shape[1]), nodes_in_batch, dtype=torch.long)
-                        batch[key][i] = torch.cat((batch[key][i], filler), dim=-1)
+                        filler = torch.full((p.shape[0], max_len - p.shape[1]),
+                                            nodes_in_batch, dtype=torch.long)
+                        batch[key][i] = torch.cat((batch[key][i], filler),
+                                                  dim=-1)
 
                 batch[key] = torch.cat(items, ref_data.__cat_dim__(key, item))
             elif isinstance(item, SparseTensor):

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -187,7 +187,8 @@ class Data(object):
         """
         # Only `*index*`, `*face*` and `paths` attributes should be cumulatively summed
         # up when creating batches.
-        return self.num_nodes if bool(re.search('(index|face)', key)) or key == 'paths' else 0
+        return self.num_nodes if bool(re.search('(index|face)',
+                                                key)) or key == 'paths' else 0
 
     @property
     def num_nodes(self):

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -185,9 +185,9 @@ class Data(object):
             if the batch concatenation process is corrupted for a specific data
             attribute.
         """
-        # Only `*index*` and `*face*` attributes should be cumulatively summed
+        # Only `*index*`, `*face*` and `paths` attributes should be cumulatively summed
         # up when creating batches.
-        return self.num_nodes if bool(re.search('(index|face)', key)) else 0
+        return self.num_nodes if bool(re.search('(index|face)', key)) or key == 'paths' else 0
 
     @property
     def num_nodes(self):


### PR DESCRIPTION
### Adding batching of arbitrary length paths and their features.

For a project of mine I needed support of arbitrarily length paths. Current behaviour was concatenating these paths into a larger list, e.g. `[[paths of graph 1], [paths of graph 2], ...]` whereas I wanted it to be `[paths of graphs 1, paths of graph 2, ...]`, i.e. similar to how `edge_index` batching was done. For further examples see `test_batch.py` (I also provide some simple tests). I also didn't want to process again the data, after it was batched.

I am open to recommendations for a different ways to implement it.

Hope anyone finds it helpful!

**EDIT1**: I decided to switch to padding, due to performance issues when using separate threads (`num_workers`>0) for loading. Currently, paths for a single datapoint (graph) should be represented as a padded tensor (|P|x|L| tensor, where, P is the set of paths, |L| is the longest path in P). Note that when padding, a padding value which is larger than the number of nodes in the batch is expected.

When batching several graphs, the padded paths for each graph are 'uppaded', so that their length matches the length of the longest path in the whole batch. Padding value is always `batch.num_nodes+1`.

