### PR TITLE
[examples] Rename logits to log_probs

### DIFF
--- a/examples/cora.py
+++ b/examples/cora.py
@@ -47,9 +47,9 @@ def train():
 
 def test():
     model.eval()
-    logits, accs = model(), []
+    log_probs, accs = model(), []
     for _, mask in data('train_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = log_probs[mask].max(1)[1]
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs


### PR DESCRIPTION
This is a minor fix for better code readability.

In examples/cora.py, the model outputs log probabilities, rather than logits (logarithm of odds ratios). This PR changes the variable name from `logits` to `log_probs`.