### PR TITLE
Added option to directly specify k for topk_pool and some pooling methods.

### DIFF
--- a/test/nn/pool/test_asap.py
+++ b/test/nn/pool/test_asap.py
@@ -24,8 +24,7 @@ def test_asap():
         assert out[0].size() == (num_nodes // 2, in_channels)
         assert out[1].size() == (2, 4)
 
-        pool = ASAPooling(in_channels, ratio=2, GNN=GNN,
-                          add_self_loops=False)
+        pool = ASAPooling(in_channels, ratio=2, GNN=GNN, add_self_loops=False)
         assert pool.__repr__() == ('ASAPooling(16, ratio=2)')
         out = pool(x, edge_index)
         assert out[0].size() == (2, in_channels)

--- a/test/nn/pool/test_asap.py
+++ b/test/nn/pool/test_asap.py
@@ -23,3 +23,10 @@ def test_asap():
         out = pool(x, edge_index)
         assert out[0].size() == (num_nodes // 2, in_channels)
         assert out[1].size() == (2, 4)
+
+        pool = ASAPooling(in_channels, ratio=2, GNN=GNN,
+                          add_self_loops=False)
+        assert pool.__repr__() == ('ASAPooling(16, ratio=2)')
+        out = pool(x, edge_index)
+        assert out[0].size() == (2, in_channels)
+        assert out[1].size() == (2, 2)

--- a/test/nn/pool/test_sag_pool.py
+++ b/test/nn/pool/test_sag_pool.py
@@ -15,22 +15,21 @@ def test_sag_pooling():
     for GNN in [GraphConv, GCNConv, GATConv, SAGEConv]:
         pool = SAGPooling(in_channels, ratio=0.5, GNN=GNN)
         assert pool.__repr__() == ('SAGPooling({}, 16, ratio=0.5, '
-                                   'multiplier=1)').format(GNN.__name__)
+                                   'multiplier=1.0)').format(GNN.__name__)
         out = pool(x, edge_index)
         assert out[0].size() == (num_nodes // 2, in_channels)
         assert out[1].size() == (2, 2)
 
         pool = SAGPooling(in_channels, ratio=None, GNN=GNN, min_score=0.1)
         assert pool.__repr__() == ('SAGPooling({}, 16, min_score=0.1, '
-                                   'multiplier=1)').format(GNN.__name__)
+                                   'multiplier=1.0)').format(GNN.__name__)
         out = pool(x, edge_index)
         assert out[0].size(0) <= x.size(0) and out[0].size(1) == (16)
         assert out[1].size(0) == 2 and out[1].size(1) <= edge_index.size(1)
 
         pool = SAGPooling(in_channels, ratio=2, GNN=GNN)
         assert pool.__repr__() == ('SAGPooling({}, 16, ratio=2, '
-                                   'multiplier=1)').format(GNN.__name__)
+                                   'multiplier=1.0)').format(GNN.__name__)
         out = pool(x, edge_index)
         assert out[0].size() == (2, in_channels)
         assert out[1].size() == (2, 2)
-

--- a/test/nn/pool/test_sag_pool.py
+++ b/test/nn/pool/test_sag_pool.py
@@ -26,3 +26,11 @@ def test_sag_pooling():
         out = pool(x, edge_index)
         assert out[0].size(0) <= x.size(0) and out[0].size(1) == (16)
         assert out[1].size(0) == 2 and out[1].size(1) <= edge_index.size(1)
+
+        pool = SAGPooling(in_channels, ratio=2, GNN=GNN)
+        assert pool.__repr__() == ('SAGPooling({}, 16, ratio=2, '
+                                   'multiplier=1)').format(GNN.__name__)
+        out = pool(x, edge_index)
+        assert out[0].size() == (2, in_channels)
+        assert out[1].size() == (2, 2)
+

--- a/test/nn/pool/test_topk_pool.py
+++ b/test/nn/pool/test_topk_pool.py
@@ -14,11 +14,12 @@ def test_topk():
     assert x[perm].tolist() == [4, 9, 6]
     assert batch[perm].tolist() == [0, 1, 1]
 
-    perm = topk(x, 2, batch)
+    perm = topk(x, 3, batch)
 
-    assert perm.tolist() == [1, 0, 5, 3]
-    assert x[perm].tolist() == [4, 2, 9, 6]
-    assert batch[perm].tolist() == [0, 0, 1, 1]
+    assert perm.tolist() == [1, 0, 5, 3, 2]
+    assert x[perm].tolist() == [4, 2, 9, 6, 5]
+    assert batch[perm].tolist() == [0, 0, 1, 1, 1]
+
 
 def test_filter_adj():
     edge_index = torch.tensor([[0, 0, 1, 1, 2, 2, 3, 3],
@@ -39,22 +40,21 @@ def test_topk_pooling():
     x = torch.randn((num_nodes, in_channels))
 
     pool = TopKPooling(in_channels, ratio=0.5)
-    assert pool.__repr__() == 'TopKPooling(16, ratio=0.5, multiplier=1)'
+    assert pool.__repr__() == 'TopKPooling(16, ratio=0.5, multiplier=1.0)'
 
     x, edge_index, _, _, _, _ = pool(x, edge_index)
     assert x.size() == (num_nodes // 2, in_channels)
     assert edge_index.size() == (2, 2)
 
     pool = TopKPooling(in_channels, ratio=None, min_score=0.1)
-    assert pool.__repr__() == 'TopKPooling(16, min_score=0.1, multiplier=1)'
+    assert pool.__repr__() == 'TopKPooling(16, min_score=0.1, multiplier=1.0)'
     out = pool(x, edge_index)
     assert out[0].size(0) <= x.size(0) and out[0].size(1) == (16)
     assert out[1].size(0) == 2 and out[1].size(1) <= edge_index.size(1)
 
     pool = TopKPooling(in_channels, ratio=2)
-    assert pool.__repr__() == 'TopKPooling(16, ratio=2, multiplier=1)'
+    assert pool.__repr__() == 'TopKPooling(16, ratio=2, multiplier=1.0)'
 
     x, edge_index, _, _, _, _ = pool(x, edge_index)
     assert x.size() == (2, in_channels)
     assert edge_index.size() == (2, 2)
-

--- a/test/nn/pool/test_topk_pool.py
+++ b/test/nn/pool/test_topk_pool.py
@@ -14,6 +14,11 @@ def test_topk():
     assert x[perm].tolist() == [4, 9, 6]
     assert batch[perm].tolist() == [0, 1, 1]
 
+    perm = topk(x, 2, batch)
+
+    assert perm.tolist() == [1, 0, 5, 3]
+    assert x[perm].tolist() == [4, 2, 9, 6]
+    assert batch[perm].tolist() == [0, 0, 1, 1]
 
 def test_filter_adj():
     edge_index = torch.tensor([[0, 0, 1, 1, 2, 2, 3, 3],
@@ -45,3 +50,11 @@ def test_topk_pooling():
     out = pool(x, edge_index)
     assert out[0].size(0) <= x.size(0) and out[0].size(1) == (16)
     assert out[1].size(0) == 2 and out[1].size(1) <= edge_index.size(1)
+
+    pool = TopKPooling(in_channels, ratio=2)
+    assert pool.__repr__() == 'TopKPooling(16, ratio=2, multiplier=1)'
+
+    x, edge_index, _, _, _, _ = pool(x, edge_index)
+    assert x.size() == (2, in_channels)
+    assert edge_index.size() == (2, 2)
+

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -1,3 +1,5 @@
+from typing import Union, Optional, Callable
+
 import torch
 import torch.nn.functional as F
 from torch.nn import Linear
@@ -17,10 +19,10 @@ class ASAPooling(torch.nn.Module):
 
     Args:
         in_channels (int): Size of each input sample.
-        ratio (float or int, optional): Graph pooling ratio, which is used to compute
+        ratio (float or int): Graph pooling ratio, which is used to compute
             :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`, or the value
-            of :math:`k` itself, depending on whether type is float or int..
-            (default: :obj:`0.5`)
+            of :math:`k` itself, depending on whether the type of :obj:`ratio`
+            is :obj:`float` or :obj:`int`. (default: :obj:`0.5`)
         GNN (torch.nn.Module, optional): A graph neural network layer for
             using intra-cluster properties.
             Especially helpful for graphs with higher degree of neighborhood
@@ -38,8 +40,10 @@ class ASAPooling(torch.nn.Module):
         **kwargs (optional): Additional parameters for initializing the
             graph neural network layer.
     """
-    def __init__(self, in_channels, ratio=0.5, GNN=None, dropout=0,
-                 negative_slope=0.2, add_self_loops=False, **kwargs):
+    def __init__(self, in_channels: int, ratio: Union[float, int] = 0.5,
+                 GNN: Optional[Callable] = None, dropout: float = 0.0,
+                 negative_slope: float = 0.2, add_self_loops: bool = False,
+                 **kwargs):
         super(ASAPooling, self).__init__()
 
         self.in_channels = in_channels

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -17,8 +17,9 @@ class ASAPooling(torch.nn.Module):
 
     Args:
         in_channels (int): Size of each input sample.
-        ratio (float, optional): Graph pooling ratio, which is used to compute
-            :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`.
+        ratio (float or int, optional): Graph pooling ratio, which is used to compute
+            :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`, or the value
+            of :math:`k` itself, depending on whether type is float or int..
             (default: :obj:`0.5`)
         GNN (torch.nn.Module, optional): A graph neural network layer for
             using intra-cluster properties.

--- a/torch_geometric/nn/pool/sag_pool.py
+++ b/torch_geometric/nn/pool/sag_pool.py
@@ -39,8 +39,9 @@ class SAGPooling(torch.nn.Module):
 
     Args:
         in_channels (int): Size of each input sample.
-        ratio (float): Graph pooling ratio, which is used to compute
-            :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`.
+        ratio (float or int): Graph pooling ratio, which is used to compute
+            :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`, or the value
+            of :math:`k` itself, depending on whether type is float or int..
             This value is ignored if min_score is not None.
             (default: :obj:`0.5`)
         GNN (torch.nn.Module, optional): A graph neural network layer for

--- a/torch_geometric/nn/pool/sag_pool.py
+++ b/torch_geometric/nn/pool/sag_pool.py
@@ -1,3 +1,5 @@
+from typing import Union, Optional, Callable
+
 import torch
 from torch_geometric.nn import GraphConv
 from torch_geometric.nn.pool.topk_pool import topk, filter_adj
@@ -41,8 +43,9 @@ class SAGPooling(torch.nn.Module):
         in_channels (int): Size of each input sample.
         ratio (float or int): Graph pooling ratio, which is used to compute
             :math:`k = \lceil \mathrm{ratio} \cdot N \rceil`, or the value
-            of :math:`k` itself, depending on whether type is float or int..
-            This value is ignored if min_score is not None.
+            of :math:`k` itself, depending on whether the type of :obj:`ratio`
+            is :obj:`float` or :obj:`int`.
+            This value is ignored if :obj:`min_score` is not :obj:`None`.
             (default: :obj:`0.5`)
         GNN (torch.nn.Module, optional): A graph neural network layer for
             calculating projection scores (one of
@@ -64,8 +67,10 @@ class SAGPooling(torch.nn.Module):
         **kwargs (optional): Additional parameters for initializing the graph
             neural network layer.
     """
-    def __init__(self, in_channels, ratio=0.5, GNN=GraphConv, min_score=None,
-                 multiplier=1, nonlinearity=torch.tanh, **kwargs):
+    def __init__(self, in_channels: int, ratio: Union[float, int] = 0.5,
+                 GNN: Callable = GraphConv, min_score: Optional[float] = None,
+                 multiplier: float = 1.0, nonlinearity: Callable = torch.tanh,
+                 **kwargs):
         super(SAGPooling, self).__init__()
 
         self.in_channels = in_channels


### PR DESCRIPTION
Small modification to directly specify the number of nodes for Top-K Pooling. Instead of looking at the ratio of pooling, directly specify the number of nodes to keep, overriding the ratio.
Put K as the last parameter in order to not break other functions.