### PR TITLE
Add tables for summarizing the classes in each module

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,6 @@ html_theme_options = {
 html_logo = '_static/img/pyg_logo_text.svg'
 html_static_path = ['_static']
 html_context = {'css_files': ['_static/css/custom.css']}
-
 rst_context = {'torch_geometric': torch_geometric}
 
 add_module_names = False
@@ -61,13 +60,8 @@ def setup(app):
         return True if name in members else skip
 
     def rst_jinja_render(app, docname, source):
-        """
-        Render our rst pages as a jinja template for easier customization
-        """
         src = source[0]
-        rendered = app.builder.templates.render_string(
-            src, rst_context
-        )
+        rendered = app.builder.templates.render_string(src, rst_context)
         source[0] = rendered
 
     app.connect('autodoc-skip-member', skip)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,8 @@ html_logo = '_static/img/pyg_logo_text.svg'
 html_static_path = ['_static']
 html_context = {'css_files': ['_static/css/custom.css']}
 
+rst_context = {'torch_geometric': torch_geometric}
+
 add_module_names = False
 
 
@@ -58,4 +60,15 @@ def setup(app):
         ]
         return True if name in members else skip
 
+    def rst_jinja_render(app, docname, source):
+        """
+        Render our rst pages as a jinja template for easier customization
+        """
+        src = source[0]
+        rendered = app.builder.templates.render_string(
+            src, rst_context
+        )
+        source[0] = rendered
+
     app.connect('autodoc-skip-member', skip)
+    app.connect("source-read", rst_jinja_render)

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -5,9 +5,8 @@ torch_geometric.datasets
 
 .. autosummary::
     :nosignatures:
-
     {% for cls in torch_geometric.datasets.classes %}
-    {{ cls }}
+      {{ cls }}
     {% endfor %}
 
 .. automodule:: torch_geometric.datasets

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -1,15 +1,14 @@
 torch_geometric.datasets
 ========================
 
-.. .. currentmodule:: torch_geometric.datasets
+.. currentmodule:: torch_geometric.datasets
 
-.. .. autosummary::
-..     :toctree: generated
-..     :nosignatures:
+.. autosummary::
+    :nosignatures:
 
-..     AMiner
-..     Amazon
-..     BitcoinOTC
+    {% for cls in torch_geometric.datasets.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.datasets
     :members:

--- a/docs/source/modules/nn.rst
+++ b/docs/source/modules/nn.rst
@@ -6,6 +6,14 @@ torch_geometric.nn
 
 Convolutional Layers
 --------------------
+.. currentmodule:: torch_geometric.nn.conv
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.conv.classes %}
+    {{ cls }}
+    {% endfor %}
+
 
 .. automodule:: torch_geometric.nn.conv.message_passing
     :members:
@@ -21,25 +29,29 @@ Convolutional Layers
 
 Dense Convolutional Layers
 --------------------------
+.. currentmodule:: torch_geometric.nn.dense
+.. autosummary::
+   :nosignatures:
 
-.. automodule:: torch_geometric.nn.dense.dense_gcn_conv
+    {% for cls in torch_geometric.nn.dense.conv_classes %}
+    {{ cls }}
+    {% endfor %}
+
+    {% for cls in torch_geometric.nn.dense.conv_classes %}
+.. autoclass:: {{ cls }}
     :members:
     :undoc-members:
-
-.. automodule:: torch_geometric.nn.dense.dense_sage_conv
-    :members:
-    :undoc-members:
-
-.. automodule:: torch_geometric.nn.dense.dense_graph_conv
-    :members:
-    :undoc-members:
-
-.. automodule:: torch_geometric.nn.dense.dense_gin_conv
-    :members:
-    :undoc-members:
+    {% endfor %}
 
 Normalization Layers
 --------------------
+.. currentmodule:: torch_geometric.nn.norm
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.norm.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.norm
     :members:
@@ -47,6 +59,13 @@ Normalization Layers
 
 Global Pooling Layers
 ---------------------
+.. currentmodule:: torch_geometric.nn.glob
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.glob.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.glob
     :members:
@@ -54,6 +73,13 @@ Global Pooling Layers
 
 Pooling Layers
 --------------
+.. currentmodule:: torch_geometric.nn.pool
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.pool.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.pool
     :members:
@@ -61,6 +87,13 @@ Pooling Layers
 
 Dense Pooling Layers
 --------------------
+.. currentmodule:: torch_geometric.nn.dense
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.dense.pool_classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.dense.diff_pool
     :members:
@@ -72,6 +105,13 @@ Dense Pooling Layers
 
 Unpooling Layers
 ----------------
+.. currentmodule:: torch_geometric.nn.unpool
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.unpool.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.unpool
     :members:
@@ -79,6 +119,13 @@ Unpooling Layers
 
 Models
 ------
+.. currentmodule:: torch_geometric.nn.models
+.. autosummary::
+   :nosignatures:
+
+    {% for cls in torch_geometric.nn.models.classes %}
+    {{ cls }}
+    {% endfor %}
 
 .. automodule:: torch_geometric.nn.models
     :members:

--- a/docs/source/modules/nn.rst
+++ b/docs/source/modules/nn.rst
@@ -9,99 +9,92 @@ Convolutional Layers
 .. currentmodule:: torch_geometric.nn.conv
 .. autosummary::
    :nosignatures:
-
-    {% for cls in torch_geometric.nn.conv.classes %}
-    {{ cls }}
-    {% endfor %}
-
+   {% for cls in torch_geometric.nn.conv.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.conv.message_passing
-    :members:
+   :members:
 
 .. automodule:: torch_geometric.nn.conv
-    :members:
-    :undoc-members:
-    :exclude-members: message, aggregate, message_and_aggregate, update, MessagePassing
+   :members:
+   :undoc-members:
+   :exclude-members: message, aggregate, message_and_aggregate, update, MessagePassing
 
 .. automodule:: torch_geometric.nn.meta
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Dense Convolutional Layers
 --------------------------
 .. currentmodule:: torch_geometric.nn.dense
 .. autosummary::
    :nosignatures:
+   {% for cls in torch_geometric.nn.dense.conv_classes %}
+     {{ cls }}
+   {% endfor %}
 
-    {% for cls in torch_geometric.nn.dense.conv_classes %}
-    {{ cls }}
-    {% endfor %}
-
-    {% for cls in torch_geometric.nn.dense.conv_classes %}
+   {% for cls in torch_geometric.nn.dense.conv_classes %}
 .. autoclass:: {{ cls }}
-    :members:
-    :undoc-members:
-    {% endfor %}
+   :members:
+   :undoc-members:
+   {% endfor %}
 
 Normalization Layers
 --------------------
 .. currentmodule:: torch_geometric.nn.norm
 .. autosummary::
    :nosignatures:
-
-    {% for cls in torch_geometric.nn.norm.classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.norm.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.norm
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Global Pooling Layers
 ---------------------
 .. currentmodule:: torch_geometric.nn.glob
 .. autosummary::
    :nosignatures:
-
-    {% for cls in torch_geometric.nn.glob.classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.glob.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.glob
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Pooling Layers
 --------------
 .. currentmodule:: torch_geometric.nn.pool
 .. autosummary::
    :nosignatures:
-
-    {% for cls in torch_geometric.nn.pool.classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.pool.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.pool
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Dense Pooling Layers
 --------------------
 .. currentmodule:: torch_geometric.nn.dense
 .. autosummary::
    :nosignatures:
-
-    {% for cls in torch_geometric.nn.dense.pool_classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.dense.pool_classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.dense.diff_pool
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 .. automodule:: torch_geometric.nn.dense.mincut_pool
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Unpooling Layers
 ----------------
@@ -109,13 +102,13 @@ Unpooling Layers
 .. autosummary::
    :nosignatures:
 
-    {% for cls in torch_geometric.nn.unpool.classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.unpool.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.unpool
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 Models
 ------
@@ -123,17 +116,17 @@ Models
 .. autosummary::
    :nosignatures:
 
-    {% for cls in torch_geometric.nn.models.classes %}
-    {{ cls }}
-    {% endfor %}
+   {% for cls in torch_geometric.nn.models.classes %}
+     {{ cls }}
+   {% endfor %}
 
 .. automodule:: torch_geometric.nn.models
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:
 
 DataParallel Layers
 -------------------
 
 .. automodule:: torch_geometric.nn.data_parallel
-    :members:
-    :undoc-members:
+   :members:
+   :undoc-members:

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -86,3 +86,5 @@ __all__ = [
     'WikiCS',
     'WebKB',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -87,4 +87,4 @@ __all__ = [
     'WebKB',
 ]
 
-classes = sorted(__all__)
+classes = __all__

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -74,4 +74,4 @@ __all__ = [
     'GCN2Conv',
 ]
 
-classes = sorted(__all__)
+classes = __all__

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -73,3 +73,5 @@ __all__ = [
     'GENConv',
     'GCN2Conv',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/nn/dense/__init__.py
+++ b/torch_geometric/nn/dense/__init__.py
@@ -5,14 +5,14 @@ from .dense_gin_conv import DenseGINConv
 from .diff_pool import dense_diff_pool
 from .mincut_pool import dense_mincut_pool
 
-conv_classes = [
+__all__ = [
     'DenseGCNConv',
     'DenseGINConv',
     'DenseGraphConv',
-    'DenseSAGEConv']
-pool_classes = [
+    'DenseSAGEConv',
     'dense_diff_pool',
     'dense_mincut_pool',
 ]
 
-__all__ = conv_classes + pool_classes
+conv_classes = __all__[:4]
+pool_classes = __all__[4:]

--- a/torch_geometric/nn/dense/__init__.py
+++ b/torch_geometric/nn/dense/__init__.py
@@ -5,11 +5,14 @@ from .dense_gin_conv import DenseGINConv
 from .diff_pool import dense_diff_pool
 from .mincut_pool import dense_mincut_pool
 
-__all__ = [
+conv_classes = [
     'DenseGCNConv',
-    'DenseSAGEConv',
-    'DenseGraphConv',
     'DenseGINConv',
+    'DenseGraphConv',
+    'DenseSAGEConv']
+pool_classes = [
     'dense_diff_pool',
     'dense_mincut_pool',
 ]
+
+__all__ = conv_classes + pool_classes

--- a/torch_geometric/nn/glob/__init__.py
+++ b/torch_geometric/nn/glob/__init__.py
@@ -11,3 +11,5 @@ __all__ = [
     'GlobalAttention',
     'Set2Set',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/nn/glob/__init__.py
+++ b/torch_geometric/nn/glob/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'Set2Set',
 ]
 
-classes = sorted(__all__)
+classes = __all__

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -29,3 +29,5 @@ __all__ = [
     'MetaPath2Vec',
     'DeepGCNLayer',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/nn/norm/__init__.py
+++ b/torch_geometric/nn/norm/__init__.py
@@ -13,3 +13,5 @@ __all__ = [
     'PairNorm',
     'MessageNorm',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -268,4 +268,4 @@ __all__ = [
     'nearest',
 ]
 
-classes = sorted(__all__)
+classes = __all__

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -267,3 +267,5 @@ __all__ = [
     'radius_graph',
     'nearest',
 ]
+
+classes = sorted(__all__)

--- a/torch_geometric/nn/unpool/__init__.py
+++ b/torch_geometric/nn/unpool/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     'knn_interpolate',
 ]
 
-classes = sorted(__all__)
+classes = __all__

--- a/torch_geometric/nn/unpool/__init__.py
+++ b/torch_geometric/nn/unpool/__init__.py
@@ -3,3 +3,5 @@ from .knn_interpolate import knn_interpolate
 __all__ = [
     'knn_interpolate',
 ]
+
+classes = sorted(__all__)


### PR DESCRIPTION
The easiest way to list all needed classes under autosummary directive
was via templating. It is not possible to directly use the `__all__`
variable in jinja templates since it is private.