### PR TITLE
jitable: do not write to potentially existing folder

### DIFF
--- a/torch_geometric/nn/conv/utils/jit.py
+++ b/torch_geometric/nn/conv/utils/jit.py
@@ -1,14 +1,16 @@
-import sys
 import os.path as osp
-from tempfile import NamedTemporaryFile as TempFile
-from importlib.util import spec_from_file_location, module_from_spec
+import sys
+from getpass import getuser
+from importlib.util import module_from_spec, spec_from_file_location
+from tempfile import NamedTemporaryFile, gettempdir
+
 from torch_geometric.data.makedirs import makedirs
 
 
 def class_from_module_repr(cls_name, module_repr):
-    path = osp.join('/tmp', 'pyg_jit')
+    path = osp.join(gettempdir(), f"{getuser()}_pyg_jit")
     makedirs(path)
-    with TempFile(mode='w+', suffix='.py', delete=False, dir=path) as f:
+    with NamedTemporaryFile(mode="w+", suffix=".py", delete=False, dir=path) as f:
         f.write(module_repr)
     spec = spec_from_file_location(cls_name, f.name)
     mod = module_from_spec(spec)


### PR DESCRIPTION
I get the below error message when calling `.jitable()`. The reason is that a different user is also running pytorch geometric - I cannot write files in their directory.

There are at least three solutions: 1) not specify a folder and let `NamedTemporaryFile` just write the file, 2) create a randomly named folder (and hope it doesn't exist), 3) do no specify a folder but provide a more meaningful suffix/prefix (e.g., `_pyg_jit.py`).

I'm happy to change this PR - currently it uses option 1).

```python-traceback
~/.cache/pypoetry/virtualenvs/python-tools-XWCSm5JO-py3.8/lib/python3.8/site-packages/torch_geometric/nn/conv/utils/jit.py in class_from_module_repr(cls_name, module_repr)
      9     path = osp.join('/tmp', 'pyg_jit')
     10     makedirs(path)
---> 11     with TempFile(mode='w+', suffix='.py', delete=False, dir=path) as f:
     12         f.write(module_repr)
     13     spec = spec_from_file_location(cls_name, f.name)

~/local/lib/python3.8/tempfile.py in NamedTemporaryFile(mode, buffering, encoding, newline, suffix, prefix, dir, delete, errors)
    538         flags |= _os.O_TEMPORARY
    539 
--> 540     (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
    541     try:
    542         file = _io.open(fd, mode, buffering=buffering,

~/local/lib/python3.8/tempfile.py in _mkstemp_inner(dir, pre, suf, flags, output_type)
    248         _sys.audit("tempfile.mkstemp", file)
    249         try:
--> 250             fd = _os.open(file, flags, 0o600)
    251         except FileExistsError:
    252             continue    # try again

PermissionError: [Errno 13] Permission denied: '/tmp/pyg_jit/tmpii_e2lzy.py'

```