### PR TITLE
feature: add input and message dependent beta to the transformer conv

### DIFF
--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -41,19 +41,20 @@ class TransformerConv(MessagePassing):
             (default: :obj:`True`)
         beta (bool, optional): If set, will combine aggregation and
             skip information via
-            
+
             .. math::
-              \beta\,\mathbf{W}_1 \vec{x}_i + (1 -
-              \beta) \underbrace{\left(\sum_{j \in \mathcal{N}(i)} \alpha_{i,j}
-              \mathbf{W}_2 \vec{x}_j \right)}_{=\mathbf{m}_i} 
-            
+                \mathbf{x}^{\prime}_i = \beta_i \mathbf{W}_1 \mathbf{x}_i +
+                (1 - \beta_i) \underbrace{\left(\sum_{j \in \mathcal{N}(i)}
+                \alpha_{i,j} \mathbf{W}_2 \vec{x}_j \right)}_{=\mathbf{m}_i}
+
             with
-            
+
             .. math::
-              \beta = \sigma(\mathbf{w}_5^T
-              [ \mathbf{x}_i \Vert \mathbf{m}_i \Vert \mathbf{x}_i - \mathbf{m}_i ])
-            
-            :math:`\sigma(\cdot)` designates the sigmoid function. (default: :obj:`False`)
+                \beta_i = \textrm{sigmoid}(\mathbf{w}_5^{\top}
+                [ \mathbf{x}_i \Vert \mathbf{m}_i \Vert
+                \mathbf{x}_i - \mathbf{m}_i ])
+
+            (default: :obj:`False`)
         dropout (float, optional): Dropout probability of the normalized
             attention coefficients which exposes each node to a stochastically
             sampled neighborhood during training. (default: :obj:`0`)
@@ -62,53 +63,53 @@ class TransformerConv(MessagePassing):
             linear transformation, that is, prior to computing the
             attention dot product. They are also added to final values
             after the same linear transformation. The model is:
-            
+
             .. math::
                 \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i +
-                \sum_{j \in \mathcal{N}(i)} \alpha_{i,j} \left( 
-                \mathbf{W}_2 \mathbf{x}_{j} + \mathbf{W}_6 \mathbf{e}_{ij} \right),
-        
-            where the attention coefficients :math:`\alpha_{i,j}` are now computed via:
-        
+                \sum_{j \in \mathcal{N}(i)} \alpha_{i,j} \left(
+                \mathbf{W}_2 \mathbf{x}_{j} + \mathbf{W}_6 \mathbf{e}_{ij}
+                \right),
+
+            where the attention coefficients :math:`\alpha_{i,j}` are now
+            computed via:
+
             .. math::
                 \alpha_{i,j} = \textrm{softmax} \left(
-                \frac{(\mathbf{W}_3\mathbf{x}_i)^{\top} (\mathbf{W}_4\mathbf{x}_j
-                + \mathbf{W}_6 \mathbf{e}_{ij})} 
+                \frac{(\mathbf{W}_3\mathbf{x}_i)^{\top}
+                (\mathbf{W}_4\mathbf{x}_j + \mathbf{W}_6 \mathbf{e}_{ij})}
                 {\sqrt{d}} \right)
-            
+
             (default :obj:`None`)
         bias (bool, optional): If set to :obj:`False`, the layer will not learn
             an additive bias. (default: :obj:`True`)
         root_weight (bool, optional): If set to :obj:`False`, the layer will
-            not add the transformed root node features to the output and the option 
-            :attr:`beta` is set to :obj:`False`. (default: :obj:`True`)
+            not add the transformed root node features to the output and the
+            option  :attr:`beta` is set to :obj:`False`. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
     _alpha: OptTensor
 
-    def __init__(self, in_channels: Union[int, Tuple[int, int]],
-                 out_channels: int, heads: int = 1, concat: bool = True,
-                 beta: bool = False, dropout: float = 0.,
-                 edge_dim: Optional[int] = None, bias: bool = True,
-                 root_weight: bool = True, **kwargs):
+    def __init__(self, in_channels: Union[int, Tuple[int,
+                                                     int]], out_channels: int,
+                 heads: int = 1, concat: bool = True, beta: bool = False,
+                 dropout: float = 0., edge_dim: Optional[int] = None,
+                 bias: bool = True, root_weight: bool = True, **kwargs):
         kwargs.setdefault('aggr', 'add')
         super(TransformerConv, self).__init__(node_dim=0, **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.heads = heads
-        self.beta = beta
+        self.beta = beta and root_weight
         self.root_weight = root_weight
-        if not root_weight:
-            self.beta = False
         self.concat = concat
         self.dropout = dropout
         self.edge_dim = edge_dim
-        
+
         if isinstance(in_channels, int):
             in_channels = (in_channels, in_channels)
-        
+
         self.lin_key = Linear(in_channels[0], heads * out_channels)
         self.lin_query = Linear(in_channels[1], heads * out_channels)
         self.lin_value = Linear(in_channels[0], heads * out_channels)
@@ -116,16 +117,18 @@ class TransformerConv(MessagePassing):
             self.lin_edge = Linear(edge_dim, heads * out_channels, bias=False)
         else:
             self.lin_edge = self.register_parameter('lin_edge', None)
-        
+
+        self.lin_beta = self.register_parameter('lin_beta', None)
+
         if concat:
             self.lin_skip = Linear(in_channels[1], heads * out_channels,
                                    bias=bias)
             if self.beta:
-                self.lin_beta = Parameter(Tensor(3*heads*out_channels))
+                self.lin_beta = Linear(3 * heads * out_channels, 1, bias=False)
         else:
             self.lin_skip = Linear(in_channels[1], out_channels, bias=bias)
             if self.beta:
-                self.lin_beta = Parameter(Tensor(3*out_channels))
+                self.lin_beta = Linear(3 * out_channels, 1, bias=False)
 
         self.reset_parameters()
 
@@ -137,14 +140,15 @@ class TransformerConv(MessagePassing):
             self.lin_edge.reset_parameters()
         self.lin_skip.reset_parameters()
         if self.beta:
-            zeros(self.lin_beta)
-        
+            self.lin_beta.reset_parameters()
+
     def forward(self, x: Union[Tensor, PairTensor], edge_index: Adj,
                 edge_attr: OptTensor = None):
+        """"""
 
         if isinstance(x, Tensor):
             x: PairTensor = (x, x)
-        
+
         # propagate_type: (x: PairTensor, edge_attr: OptTensor)
         out = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=None)
 
@@ -152,28 +156,28 @@ class TransformerConv(MessagePassing):
             out = out.view(-1, self.heads * self.out_channels)
         else:
             out = out.mean(dim=1)
-        
+
         if self.root_weight:
-            x = self.lin_skip(x[1])
-            if self.beta:
-                beta = (self.lin_beta * torch.cat( (out, x, out-x), dim=-1) ).sum(dim=-1) 
-                beta = torch.sigmoid( beta ).view(-1,1)
-                out = beta * x + (1 - beta) * out
+            x_r = self.lin_skip(x[1])
+            if self.lin_beta is not None:
+                beta = self.lin_beta(torch.cat([out, x_r, out - x_r], dim=-1))
+                beta = beta.sigmoid()
+                out = beta * x_r + (1 - beta) * out
             else:
-                out += x
+                out += x_r
 
         return out
 
-    def message(self, x_i: Tensor, x_j: Tensor, edge_attr: Optional[Tensor],
+    def message(self, x_i: Tensor, x_j: Tensor, edge_attr: OptTensor,
                 index: Tensor, ptr: OptTensor,
                 size_i: Optional[int]) -> Tensor:
 
         query = self.lin_query(x_i).view(-1, self.heads, self.out_channels)
         key = self.lin_key(x_j).view(-1, self.heads, self.out_channels)
-        
-        if edge_attr is not None:
+
+        if self.lin_edge is not None:
             edge_attr = self.lin_edge(edge_attr).view(-1, self.heads,
-                                                 self.out_channels)
+                                                      self.out_channels)
             key += edge_attr
 
         alpha = (query * key).sum(dim=-1) / math.sqrt(self.out_channels)

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -2,11 +2,15 @@ import math
 from typing import Union, Tuple, Optional
 from torch_geometric.typing import PairTensor, Adj, OptTensor
 
+import torch
 from torch import Tensor
 import torch.nn.functional as F
 from torch.nn import Linear
+from torch.nn import Parameter
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.utils import softmax
+
+from ..inits import zeros
 
 
 class TransformerConv(MessagePassing):
@@ -35,17 +39,49 @@ class TransformerConv(MessagePassing):
         concat (bool, optional): If set to :obj:`False`, the multi-head
             attentions are averaged instead of concatenated.
             (default: :obj:`True`)
-        beta (float, optional): If set, will combine aggregation and
-            skip information via :math:`\beta\,\mathbf{W}_1 \vec{x}_i + (1 -
-            \beta) \left(\sum_{j \in \mathcal{N}(i)} \alpha_{i,j} \mathbf{W}_2
-            \vec{x}_j \right)`. (default: :obj:`None`)
+        beta (bool, optional): If set, will combine aggregation and
+            skip information via
+            
+            .. math::
+              \beta\,\mathbf{W}_1 \vec{x}_i + (1 -
+              \beta) \underbrace{\left(\sum_{j \in \mathcal{N}(i)} \alpha_{i,j}
+              \mathbf{W}_2 \vec{x}_j \right)}_{=\mathbf{m}_i} 
+            
+            with
+            
+            .. math::
+              \beta = \sigma(\mathbf{w}_5^T
+              [ \mathbf{x}_i \Vert \mathbf{m}_i \Vert \mathbf{x}_i - \mathbf{m}_i ])
+            
+            :math:`\sigma(\cdot)` designates the sigmoid function. (default: :obj:`False`)
         dropout (float, optional): Dropout probability of the normalized
             attention coefficients which exposes each node to a stochastically
             sampled neighborhood during training. (default: :obj:`0`)
         edge_dim (int, optional): Edge feature dimensionality (in case
-            there are any). (default :obj:`None`)
+            there are any). Edge features are added to the keys after
+            linear transformation, that is, prior to computing the
+            attention dot product. They are also added to final values
+            after the same linear transformation. The model is:
+            
+            .. math::
+                \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i +
+                \sum_{j \in \mathcal{N}(i)} \alpha_{i,j} \left( 
+                \mathbf{W}_2 \mathbf{x}_{j} + \mathbf{W}_6 \mathbf{e}_{ij} \right),
+        
+            where the attention coefficients :math:`\alpha_{i,j}` are now computed via:
+        
+            .. math::
+                \alpha_{i,j} = \textrm{softmax} \left(
+                \frac{(\mathbf{W}_3\mathbf{x}_i)^{\top} (\mathbf{W}_4\mathbf{x}_j
+                + \mathbf{W}_6 \mathbf{e}_{ij})} 
+                {\sqrt{d}} \right)
+            
+            (default :obj:`None`)
         bias (bool, optional): If set to :obj:`False`, the layer will not learn
             an additive bias. (default: :obj:`True`)
+        root_weight (bool, optional): If set to :obj:`False`, the layer will
+            not add the transformed root node features to the output and the option 
+            :attr:`beta` is set to :obj:`False`. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
@@ -53,35 +89,43 @@ class TransformerConv(MessagePassing):
 
     def __init__(self, in_channels: Union[int, Tuple[int, int]],
                  out_channels: int, heads: int = 1, concat: bool = True,
-                 beta: Optional[float] = None, dropout: float = 0.,
-                 edge_dim: Optional[int] = None, bias: bool = True, **kwargs):
+                 beta: bool = False, dropout: float = 0.,
+                 edge_dim: Optional[int] = None, bias: bool = True,
+                 root_weight: bool = True, **kwargs):
         kwargs.setdefault('aggr', 'add')
         super(TransformerConv, self).__init__(node_dim=0, **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.heads = heads
-        self.concat = concat
         self.beta = beta
+        self.root_weight = root_weight
+        if not root_weight:
+            self.beta = False
+        self.concat = concat
         self.dropout = dropout
         self.edge_dim = edge_dim
-
+        
         if isinstance(in_channels, int):
             in_channels = (in_channels, in_channels)
-
+        
         self.lin_key = Linear(in_channels[0], heads * out_channels)
         self.lin_query = Linear(in_channels[1], heads * out_channels)
         self.lin_value = Linear(in_channels[0], heads * out_channels)
         if edge_dim is not None:
             self.lin_edge = Linear(edge_dim, heads * out_channels, bias=False)
         else:
-            self.lin_edge = Linear(1, 1)
-
+            self.lin_edge = self.register_parameter('lin_edge', None)
+        
         if concat:
             self.lin_skip = Linear(in_channels[1], heads * out_channels,
                                    bias=bias)
+            if self.beta:
+                self.lin_beta = Parameter(Tensor(3*heads*out_channels))
         else:
             self.lin_skip = Linear(in_channels[1], out_channels, bias=bias)
+            if self.beta:
+                self.lin_beta = Parameter(Tensor(3*out_channels))
 
         self.reset_parameters()
 
@@ -92,13 +136,15 @@ class TransformerConv(MessagePassing):
         if self.edge_dim:
             self.lin_edge.reset_parameters()
         self.lin_skip.reset_parameters()
-
+        if self.beta:
+            zeros(self.lin_beta)
+        
     def forward(self, x: Union[Tensor, PairTensor], edge_index: Adj,
                 edge_attr: OptTensor = None):
 
         if isinstance(x, Tensor):
             x: PairTensor = (x, x)
-
+        
         # propagate_type: (x: PairTensor, edge_attr: OptTensor)
         out = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=None)
 
@@ -106,12 +152,15 @@ class TransformerConv(MessagePassing):
             out = out.view(-1, self.heads * self.out_channels)
         else:
             out = out.mean(dim=1)
-
-        x = self.lin_skip(x[1])
-        if self.beta is not None:
-            out = self.beta * x + (1 - self.beta) * out
-        else:
-            out += x
+        
+        if self.root_weight:
+            x = self.lin_skip(x[1])
+            if self.beta:
+                beta = (self.lin_beta * torch.cat( (out, x, out-x), dim=-1) ).sum(dim=-1) 
+                beta = torch.sigmoid( beta ).view(-1,1)
+                out = beta * x + (1 - beta) * out
+            else:
+                out += x
 
         return out
 
@@ -119,12 +168,11 @@ class TransformerConv(MessagePassing):
                 index: Tensor, ptr: OptTensor,
                 size_i: Optional[int]) -> Tensor:
 
-        query = self.lin_key(x_j).view(-1, self.heads, self.out_channels)
-        key = self.lin_query(x_i).view(-1, self.heads, self.out_channels)
-
-        lin_edge = self.lin_edge
+        query = self.lin_query(x_i).view(-1, self.heads, self.out_channels)
+        key = self.lin_key(x_j).view(-1, self.heads, self.out_channels)
+        
         if edge_attr is not None:
-            edge_attr = lin_edge(edge_attr).view(-1, self.heads,
+            edge_attr = self.lin_edge(edge_attr).view(-1, self.heads,
                                                  self.out_channels)
             key += edge_attr
 


### PR DESCRIPTION
Hi,

1/ With the option `beta` set to `True`, the model parameter `beta` is input and message dependent, as in the paper.
2/ I extended the documentation if the dimension of edge features is passed to the constructor.
3/ with `root_weight`, it is possible to ignore everything but the message; I took `root_weight` from another conv (for consistency across convs) though I found it a bit misleading; I would prefer `target_weight` or `skip_connection`; It would be nice if every conv had this argument, so that we could easily plug the message into a RNN (as in GeniePath) without having to re-code a conv to avoid updating the target node.

regards
Laurent