### PR TITLE
Fixed from_networkx to support empty edges list

### DIFF
--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -115,7 +115,7 @@ def from_networkx(G):
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    edge_index = torch.tensor(list(G.edges)).t().contiguous()
+    edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
 
     data = {}
 


### PR DESCRIPTION

In the ` from_networkx() ` function, in case the networkx graph has no edges, the operation
```
edge_index = torch.tensor(list(G.edges)).t().contiguous()
```
creates a `torch.float32` tensor which leads to an assertion failure in `nn/conv/message_passing.py`:
```
    def __check_input__(self, edge_index, size):
        the_size: List[Optional[int]] = [None, None]

        if isinstance(edge_index, Tensor):
            assert edge_index.dtype == torch.long
```

The fix:
Creating `LongTensor` explicitly:
```
edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
```