### PR TITLE
Fixed Data attribute check in GCNNorm

### DIFF
--- a/torch_geometric/transforms/gcn_norm.py
+++ b/torch_geometric/transforms/gcn_norm.py
@@ -16,9 +16,9 @@ class GCNNorm(object):
         self.add_self_loops = add_self_loops
 
     def __call__(self, data):
-        assert data.edge_index is not None or data.adj_t is not None
+        assert 'edge_index' in data or 'adj_t' in data
 
-        if data.edge_index is not None:
+        if 'edge_index' in data:
             edge_weight = data.edge_attr
             if 'edge_weight' in data:
                 edge_weight = data.edge_weight


### PR DESCRIPTION
The original check `data.edge_index is not None`  raises an `AttributeError: 'Data' object has no attribute 'edge_index'` in case it's missing from the object.