### PR TITLE
Support for concatenating along a new batch dimension

### DIFF
--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -50,34 +50,40 @@ def test_batch():
     torch_geometric.set_debug(True)
 
 
-def test_newaxis_batching():
+def test_batching_with_new_dimension():
+    torch_geometric.set_debug(True)
+
     class MyData(Data):
         def __cat_dim__(self, key, item):
-            if key == 'newaxis_field':
-                return None
-            else:
-                return super().__cat_dim__(key, item)
+            return None if key == 'foo' else super().__cat_dim__(key, item)
+
+    x1 = torch.tensor([1, 2, 3], dtype=torch.float)
+    foo1 = torch.randn(4)
+    y1 = torch.tensor(1)
+
+    x2 = torch.tensor([1, 2], dtype=torch.float)
+    foo2 = torch.randn(4)
+    y2 = torch.tensor(2)
+
+    batch = Batch.from_data_list(
+        [MyData(x=x1, foo=foo1, y=y1),
+         MyData(x=x2, foo=foo2, y=y2)])
+
+    assert batch.__repr__() == (
+        'Batch(batch=[5], foo=[2, 4], ptr=[3], x=[5], y=[2])')
+    assert len(batch) == 5
+    assert batch.x.tolist() == [1, 2, 3, 1, 2]
+    assert batch.foo.size() == (2, 4)
+    assert batch.foo[0].tolist() == foo1.tolist()
+    assert batch.foo[1].tolist() == foo2.tolist()
+    assert batch.y.tolist() == [1, 2]
+    assert batch.batch.tolist() == [0, 0, 0, 1, 1]
+    assert batch.ptr.tolist() == [0, 3, 5]
+    assert batch.num_graphs == 2
+
+    data = batch[0]
+    assert data.__repr__() == ('MyData(foo=[4], x=[3], y=1)')
+    data = batch[1]
+    assert data.__repr__() == ('MyData(foo=[4], x=[2], y=2)')
 
     torch_geometric.set_debug(True)
-    N_datas = 3
-    N_nodes = torch.randint(low=3, high=10, size=(N_datas,))
-    N_features = 8
-    target_shape = (4, 7)
-    datas = [
-        MyData(
-            x=torch.randn(n_node, N_features),
-            newaxis_field=torch.randn(target_shape)
-        )
-        for n_node in N_nodes
-    ]
-
-    batch = Batch.from_data_list(datas)
-
-    assert batch.x.shape == (sum(N_nodes), N_features)
-    assert batch.newaxis_field.shape == (N_datas,) + target_shape
-    for i in range(N_datas):
-        orig = datas[i].newaxis_field
-        from_batch = batch.get_example(i).newaxis_field
-        assert orig.shape == target_shape
-        assert orig.shape == from_batch.shape
-        assert torch.all(orig == from_batch)

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -50,15 +50,14 @@ def test_batch():
     torch_geometric.set_debug(True)
 
 
-class MyData(Data):
-    def __cat_dim__(self, key, item):
-        if key == 'per_graph_tensor':
-            return None
-        else:
-            return super().__cat_dim__(key, item)
-
-
 def test_newaxis_batching():
+    class MyData(Data):
+        def __cat_dim__(self, key, item):
+            if key == 'newaxis_field':
+                return None
+            else:
+                return super().__cat_dim__(key, item)
+
     torch_geometric.set_debug(True)
     N_datas = 3
     N_nodes = torch.randint(low=3, high=10, size=(N_datas,))
@@ -67,7 +66,7 @@ def test_newaxis_batching():
     datas = [
         MyData(
             x=torch.randn(n_node, N_features),
-            per_graph_tensor=torch.randn(target_shape)
+            newaxis_field=torch.randn(target_shape)
         )
         for n_node in N_nodes
     ]
@@ -75,10 +74,10 @@ def test_newaxis_batching():
     batch = Batch.from_data_list(datas)
 
     assert batch.x.shape == (sum(N_nodes), N_features)
-    assert batch.per_graph_tensor.shape == (N_datas,) + target_shape
+    assert batch.newaxis_field.shape == (N_datas,) + target_shape
     for i in range(N_datas):
-        orig = datas[i].per_graph_tensor
-        from_batch = batch.get_example(i).per_graph_tensor
+        orig = datas[i].newaxis_field
+        from_batch = batch.get_example(i).newaxis_field
         assert orig.shape == target_shape
         assert orig.shape == from_batch.shape
         assert torch.all(orig == from_batch)

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -2,9 +2,9 @@ import torch
 from torch_geometric.data import Data, InMemoryDataset
 
 
-class DatasetFromList(InMemoryDataset):
+class TestDataset(InMemoryDataset):
     def __init__(self, data_list):
-        super(DatasetFromList, self).__init__('/tmp/TestDataset')
+        super(TestDataset, self).__init__('/tmp/TestDataset')
         self.data, self.slices = self.collate(data_list)
 
 
@@ -21,7 +21,7 @@ def test_in_memory_dataset():
     data2 = Data(x=x, edge_index=edge_index, face=face, test_int=i, test_str=s)
     data2.num_nodes = 5
 
-    dataset = DatasetFromList([data1, data2])
+    dataset = TestDataset([data1, data2])
     assert len(dataset) == 2
     assert dataset[0].num_nodes == 10
     assert len(dataset[0]) == 5
@@ -29,31 +29,28 @@ def test_in_memory_dataset():
     assert len(dataset[1]) == 5
 
 
-def test_newaxis_batching():
+def test_collate_with_new_dimension():
     class MyData(Data):
         def __cat_dim__(self, key, item):
-            if key == 'newaxis_field':
-                return None
-            else:
-                return super().__cat_dim__(key, item)
+            return None if key == 'foo' else super().__cat_dim__(key, item)
 
-    N_datas = 3
-    N_nodes = torch.randint(low=3, high=10, size=(N_datas,))
-    N_features = 8
-    target_shape = (4, 7)
-    datas = [
-        MyData(
-            x=torch.randn(n_node, N_features),
-            newaxis_field=torch.randn(target_shape)
-        )
-        for n_node in N_nodes
-    ]
+    x = torch.tensor([1, 2, 3], dtype=torch.float)
+    foo = torch.randn(4)
+    y = torch.tensor(1)
 
-    dataset = DatasetFromList(datas)
+    data = MyData(x=x, foo=foo, y=y)
 
-    assert len(dataset) == N_datas
-    for orig, from_dataset in zip(datas, dataset):
-        assert orig.x.shape == from_dataset.x.shape
-        assert torch.all(orig.x == from_dataset.x)
-        assert orig.newaxis_field.shape == from_dataset.newaxis_field.shape
-        assert torch.all(orig.newaxis_field == from_dataset.newaxis_field)
+    dataset = TestDataset([data, data])
+    assert len(dataset) == 2
+
+    data1 = dataset[0]
+    assert len(data1) == 3
+    assert data1.x.tolist() == x.tolist()
+    assert data1.foo.tolist() == foo.tolist()
+    assert data1.y.tolist() == [1]
+
+    data2 = dataset[0]
+    assert len(data2) == 3
+    assert data2.x.tolist() == x.tolist()
+    assert data2.foo.tolist() == foo.tolist()
+    assert data2.y.tolist() == [1]

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -2,12 +2,13 @@ import torch
 from torch_geometric.data import Data, InMemoryDataset
 
 
-def test_in_memory_dataset():
-    class TestDataset(InMemoryDataset):
-        def __init__(self, data_list):
-            super(TestDataset, self).__init__('/tmp/TestDataset')
-            self.data, self.slices = self.collate(data_list)
+class DatasetFromList(InMemoryDataset):
+    def __init__(self, data_list):
+        super(DatasetFromList, self).__init__('/tmp/TestDataset')
+        self.data, self.slices = self.collate(data_list)
 
+
+def test_in_memory_dataset():
     x = torch.Tensor([[1], [1], [1]])
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     face = torch.tensor([[0], [1], [2]])
@@ -20,9 +21,39 @@ def test_in_memory_dataset():
     data2 = Data(x=x, edge_index=edge_index, face=face, test_int=i, test_str=s)
     data2.num_nodes = 5
 
-    dataset = TestDataset([data1, data2])
+    dataset = DatasetFromList([data1, data2])
     assert len(dataset) == 2
     assert dataset[0].num_nodes == 10
     assert len(dataset[0]) == 5
     assert dataset[1].num_nodes == 5
     assert len(dataset[1]) == 5
+
+
+def test_newaxis_batching():
+    class MyData(Data):
+        def __cat_dim__(self, key, item):
+            if key == 'newaxis_field':
+                return None
+            else:
+                return super().__cat_dim__(key, item)
+
+    N_datas = 3
+    N_nodes = torch.randint(low=3, high=10, size=(N_datas,))
+    N_features = 8
+    target_shape = (4, 7)
+    datas = [
+        MyData(
+            x=torch.randn(n_node, N_features),
+            newaxis_field=torch.randn(target_shape)
+        )
+        for n_node in N_nodes
+    ]
+
+    dataset = DatasetFromList(datas)
+
+    assert len(dataset) == N_datas
+    for orig, from_dataset in zip(datas, dataset):
+        assert orig.x.shape == from_dataset.x.shape
+        assert torch.all(orig.x == from_dataset.x)
+        assert orig.newaxis_field.shape == from_dataset.newaxis_field.shape
+        assert torch.all(orig.newaxis_field == from_dataset.newaxis_field)

--- a/torch_geometric/data/in_memory_dataset.py
+++ b/torch_geometric/data/in_memory_dataset.py
@@ -100,10 +100,10 @@ class InMemoryDataset(Dataset):
         return data
 
     @staticmethod
-    def collate(data_list):
+    def collate(data_list, exclude_keys=[]):
         r"""Collates a python list of data objects to the internal storage
         format of :class:`torch_geometric.data.InMemoryDataset`."""
-        keys = data_list[0].keys
+        keys = list(set(data_list[0].keys) - set(exclude_keys))
         data = data_list[0].__class__()
 
         for key in keys:


### PR DESCRIPTION
Adds the first feature from issue #2030.

TODO:
- [x] Support for a `__cat_dim__` of `None` in `Batch.from_data_list`
- [x]  Support for the same in `InMemoryDataset`
- [x] Update documentation