### PR TITLE
Fix downloading error caused by file name suffix "?dl=1"

### DIFF
--- a/torch_geometric/data/download.py
+++ b/torch_geometric/data/download.py
@@ -17,7 +17,7 @@ def download_url(url, folder, log=True):
             console. (default: :obj:`True`)
     """
 
-    filename = url.rpartition('/')[2]
+    filename = url.rpartition('/')[2].split("?")[0]
     path = osp.join(folder, filename)
 
     if osp.exists(path):  # pragma: no cover

--- a/torch_geometric/data/download.py
+++ b/torch_geometric/data/download.py
@@ -17,7 +17,7 @@ def download_url(url, folder, log=True):
             console. (default: :obj:`True`)
     """
 
-    filename = url.rpartition('/')[2].split("?")[0]
+    filename = url.rpartition('/')[2].split('?')[0]
     path = osp.join(folder, filename)
 
     if osp.exists(path):  # pragma: no cover


### PR DESCRIPTION
Fix file writing error while downloading data from "https://www.dropbox.com/s/1bnz8r7mofx0osf/net_aminer.zip?dl=1", caused by the suffix "?dl=1".