### PR TITLE
Fix num_classes to be integer

### DIFF
--- a/torch_geometric/data/in_memory_dataset.py
+++ b/torch_geometric/data/in_memory_dataset.py
@@ -59,7 +59,7 @@ class InMemoryDataset(Dataset):
     def num_classes(self):
         r"""The number of classes in the dataset."""
         y = self.data.y
-        return y.max().item() + 1 if y.dim() == 1 else y.size(1)
+        return int(y.max().item() + 1 if y.dim() == 1 else y.size(1))
 
     def len(self):
         for item in self.slices.values():


### PR DESCRIPTION
Sometimes `dataset.num_classes` is not an integer, and this may cause issues in the code. Here is an example: 
```python
from torch_geometric.datasets import WikipediaNetwork
from torch_geometric.nn import GCNConv
dataset = WikipediaNetwork(root='/tmp/Chameleon', name='Chameleon')

conv1 = GCNConv(dataset.num_features, 16)

# here dataset.num_classes=5.0, which will make GCNConv throw an error
conv2 = GCNConv(16, dataset.num_classes)
```
A simple fix is to cast the `num_classes` property to be an interger, since it seems like we never expect this property to be a non-integer. 