### PR TITLE
Fix error in DenseGraphConv triggered when aggr is max

### DIFF
--- a/test/nn/dense/test_dense_graph_conv.py
+++ b/test/nn/dense/test_dense_graph_conv.py
@@ -1,11 +1,14 @@
+import pytest
+
 import torch
 from torch_geometric.nn import GraphConv, DenseGraphConv
 
 
-def test_dense_graph_conv():
+@pytest.mark.parametrize('aggr', ['add', 'mean', 'max'])
+def test_dense_graph_conv(aggr):
     channels = 16
-    sparse_conv = GraphConv(channels, channels)
-    dense_conv = DenseGraphConv(channels, channels)
+    sparse_conv = GraphConv(channels, channels, aggr=aggr)
+    dense_conv = DenseGraphConv(channels, channels, aggr=aggr)
     assert dense_conv.__repr__() == 'DenseGraphConv(16, 16)'
 
     # Ensure same weights and bias.
@@ -36,15 +39,16 @@ def test_dense_graph_conv():
 
     dense_out = dense_conv(x, adj, mask)
     assert dense_out.size() == (2, 3, channels)
+    dense_out = dense_out.view(-1, channels)
 
-    assert dense_out[1, 2].abs().sum().item() == 0
-    dense_out = dense_out.view(6, channels)[:-1]
-    assert torch.allclose(sparse_out, dense_out, atol=1e-04)
+    assert torch.allclose(sparse_out, dense_out[:5], atol=1e-04)
+    assert dense_out[-1].abs().sum() == 0
 
 
-def test_dense_graph_conv_with_broadcasting():
+@pytest.mark.parametrize('aggr', ['add', 'mean', 'max'])
+def test_dense_graph_conv_with_broadcasting(aggr):
     batch_size, num_nodes, channels = 8, 3, 16
-    conv = DenseGraphConv(channels, channels)
+    conv = DenseGraphConv(channels, channels, aggr=aggr)
 
     x = torch.randn(batch_size, num_nodes, channels)
     adj = torch.Tensor([

--- a/torch_geometric/nn/dense/dense_graph_conv.py
+++ b/torch_geometric/nn/dense/dense_graph_conv.py
@@ -39,19 +39,24 @@ class DenseGraphConv(torch.nn.Module):
         """
         x = x.unsqueeze(0) if x.dim() == 2 else x
         adj = adj.unsqueeze(0) if adj.dim() == 2 else adj
-        B, N, _ = adj.size()
+        B, N, C = x.size()
 
-        out = self.lin_rel(torch.matmul(adj, x))
-
-        if self.aggr == 'mean':
-            out = out / adj.sum(dim=-1, keepdim=True).clamp(min=1)
+        if self.aggr in ['add', 'mean']:
+            out = torch.matmul(adj, x)
+            if self.aggr == 'mean':
+                out = out / adj.sum(dim=-1, keepdim=True).clamp_(min=1)
         elif self.aggr == 'max':
-            out = out.max(dim=-1, keepdim=True)[0]
+            out = x.unsqueeze(-2).repeat(1, 1, N, 1)
+            adj = adj.unsqueeze(-1).expand(B, N, N, C)
+            out[adj == 0] = float('-inf')
+            out = out.max(dim=-3)[0]
+            out[out == float('-inf')] = 0.
 
-        out = out + self.lin_root(x)
+        out = self.lin_rel(out)
+        out += self.lin_root(x)
 
         if mask is not None:
-            out = out * mask.view(B, N, 1).to(x.dtype)
+            out = out * mask.view(-1, N, 1).to(x.dtype)
 
         return out
 

--- a/torch_geometric/nn/dense/dense_graph_conv.py
+++ b/torch_geometric/nn/dense/dense_graph_conv.py
@@ -46,9 +46,9 @@ class DenseGraphConv(torch.nn.Module):
         if self.aggr == 'mean':
             out = out / adj.sum(dim=-1, keepdim=True).clamp(min=1)
         elif self.aggr == 'max':
-            out = out.max(dim=-1)[0]
+            out = out.max(dim=-1, keepdim=True)[0]
 
-        out += self.lin_root(x)
+        out = out + self.lin_root(x)
 
         if mask is not None:
             out = out * mask.view(B, N, 1).to(x.dtype)


### PR DESCRIPTION
In original implementation of DenseGraphConv, dimention mismatch error occured when aggr is max.

```python

# keep dimention while using max
# out = out.max(dim=-1)[0]
out = out.max(dim=-1, keepdim=True)[0]

# change the way to merge output of lin_rel and lin_root
# out += self.lin_root(x)
out = out + self.lin_root(x)

```