### PR TITLE
Number of classes in datasets with no y

### DIFF
--- a/torch_geometric/data/in_memory_dataset.py
+++ b/torch_geometric/data/in_memory_dataset.py
@@ -60,6 +60,7 @@ class InMemoryDataset(Dataset):
     def num_classes(self):
         r"""The number of classes in the dataset."""
         y = self.data.y
+        if y is None: return 0
         return int(y.max().item() + 1 if y.dim() == 1 else y.size(1))
 
     def len(self):

--- a/torch_geometric/data/in_memory_dataset.py
+++ b/torch_geometric/data/in_memory_dataset.py
@@ -59,9 +59,12 @@ class InMemoryDataset(Dataset):
     @property
     def num_classes(self):
         r"""The number of classes in the dataset."""
-        y = self.data.y
-        if y is None: return 0
-        return int(y.max().item() + 1 if y.dim() == 1 else y.size(1))
+        if self.data.y is None:
+            return 0
+        elif self.data.y.dim() == 1:
+            return int(self.data.y.max().item()) + 1
+        else:
+            return self.data.y.size(-1)
 
     def len(self):
         for item in self.slices.values():


### PR DESCRIPTION
I noticed, while exploring around on Epinions1 dataset of SNAPDataset, that it raises an error when you try to see the number of classes. In general, num_classes doesn't handle datasets with Nonetype of y. It seemed logical that if there is no y then it should return 0 instead of an error.

P.S: I'm new to the library. Please, nevermind this pull request if the way it works is intentional.