### PR TITLE
fix s3dis.py error in windows system

### DIFF
--- a/torch_geometric/datasets/s3dis.py
+++ b/torch_geometric/datasets/s3dis.py
@@ -65,7 +65,7 @@ class S3DIS(InMemoryDataset):
         extract_zip(path, self.root)
         os.unlink(path)
         shutil.rmtree(self.raw_dir)
-        name = self.url.split(os.sep)[-1].split('.')[0]
+        name = self.url.split('/')[-1].split('.')[0]
         os.rename(osp.join(self.root, name), self.raw_dir)
 
     def process(self):


### PR DESCRIPTION
In windows environment os.sep is not '/', so
 `name = self.url.split(os.sep)[-1].split('.')[0]`
`os.rename(osp.join(self.root, name), self.raw_dir)`
 cause OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect.
