### PR TITLE
Local cartesian: make normalization optional

### DIFF
--- a/test/transforms/test_cartesian.py
+++ b/test/transforms/test_cartesian.py
@@ -8,19 +8,19 @@ def test_cartesian():
 
     pos = torch.Tensor([[-1, 0], [0, 0], [2, 0]])
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
-    edge_attr = torch.Tensor([1, 1, 1, 1])
+    edge_attr = torch.Tensor([1, 2, 3, 4])
 
     data = Data(edge_index=edge_index, pos=pos)
     data = Cartesian(norm=False)(data)
     assert len(data) == 3
     assert data.pos.tolist() == pos.tolist()
     assert data.edge_index.tolist() == edge_index.tolist()
-    assert data.edge_attr.tolist() == [[1, 0], [-1, 0], [2, 0], [-2, 0]]
+    assert data.edge_attr.tolist() == [[-1, 0], [1, 0], [-2, 0], [2, 0]]
 
     data = Data(edge_index=edge_index, pos=pos, edge_attr=edge_attr)
     data = Cartesian(norm=True)(data)
     assert len(data) == 3
     assert data.pos.tolist() == pos.tolist()
     assert data.edge_index.tolist() == edge_index.tolist()
-    assert data.edge_attr.tolist() == [[1, 0.75, 0.5], [1, 0.25, 0.5],
-                                       [1, 1, 0.5], [1, 0, 0.5]]
+    assert data.edge_attr.tolist() == [[1, 0.25, 0.5], [2, 0.75, 0.5],
+                                       [3, 0, 0.5], [4, 1, 0.5]]

--- a/test/transforms/test_local_cartesian.py
+++ b/test/transforms/test_local_cartesian.py
@@ -15,13 +15,13 @@ def test_local_cartesian():
     assert len(data) == 3
     assert data.pos.tolist() == pos.tolist()
     assert data.edge_index.tolist() == edge_index.tolist()
-    assert data.edge_attr.tolist() == [[0.75, 0.5], [0.0, 0.5], [1.0, 0.5],
-                                       [0.0, 0.5]]
+    assert data.edge_attr.tolist() == [[0.25, 0.5], [1.0, 0.5], [0.0, 0.5],
+                                       [1.0, 0.5]]
 
     data = Data(edge_index=edge_index, pos=pos, edge_attr=edge_attr)
     data = LocalCartesian()(data)
     assert len(data) == 3
     assert data.pos.tolist() == pos.tolist()
     assert data.edge_index.tolist() == edge_index.tolist()
-    assert data.edge_attr.tolist() == [[1, 0.75, 0.5], [2, 0.0, 0.5],
-                                       [3, 1.0, 0.5], [4, 0.0, 0.5]]
+    assert data.edge_attr.tolist() == [[1, 0.25, 0.5], [2, 1.0, 0.5],
+                                       [3, 0.0, 0.5], [4, 1.0, 0.5]]

--- a/torch_geometric/nn/conv/gmm_conv.py
+++ b/torch_geometric/nn/conv/gmm_conv.py
@@ -49,6 +49,13 @@ class GMMConv(MessagePassing):
             an additive bias. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
+    
+    .. note::
+        The edge attribute :math:`\mathbf{e}_{ij}` is usually given by
+        :math:`\mathbf{e}_{ij} = \mathbf{p}_j - \mathbf{p}_i` where 
+        :math:`\mathbf{p}_i` is the Cartesian position of node :math:`i`.
+        See the handy function :class:`torch_geometric.transforms.LocalCartesian`.
+    
     """
     def __init__(self, in_channels: Union[int, Tuple[int, int]],
                  out_channels: int, dim: int, kernel_size: int,

--- a/torch_geometric/nn/conv/gmm_conv.py
+++ b/torch_geometric/nn/conv/gmm_conv.py
@@ -30,6 +30,13 @@ class GMMConv(MessagePassing):
     :math:`\mathbf{\mu}_k` and diagonal covariance matrix
     :math:`\mathbf{\Sigma}_k`.
 
+    .. note::
+
+        The edge attribute :math:`\mathbf{e}_{ij}` is usually given by
+        :math:`\mathbf{e}_{ij} = \mathbf{p}_j - \mathbf{p}_i`, where
+        :math:`\mathbf{p}_i` denotes the position of node :math:`i` (see
+        :class:`torch_geometric.transform.Cartesian`).
+
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
             corresponds to the sizes of source and target dimensionalities.
@@ -49,13 +56,7 @@ class GMMConv(MessagePassing):
             an additive bias. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
-    
-    .. note::
-        The edge attribute :math:`\mathbf{e}_{ij}` is usually given by
-        :math:`\mathbf{e}_{ij} = \mathbf{p}_j - \mathbf{p}_i` where 
-        :math:`\mathbf{p}_i` is the Cartesian position of node :math:`i`.
-        See the handy function :class:`torch_geometric.transforms.LocalCartesian`.
-    
+
     """
     def __init__(self, in_channels: Union[int, Tuple[int, int]],
                  out_channels: int, dim: int, kernel_size: int,

--- a/torch_geometric/transforms/cartesian.py
+++ b/torch_geometric/transforms/cartesian.py
@@ -23,7 +23,7 @@ class Cartesian(object):
     def __call__(self, data):
         (row, col), pos, pseudo = data.edge_index, data.pos, data.edge_attr
 
-        cart = pos[col] - pos[row]
+        cart = pos[row] - pos[col]
         cart = cart.view(-1, 1) if cart.dim() == 1 else cart
 
         if self.norm and cart.numel() > 0:

--- a/torch_geometric/transforms/local_cartesian.py
+++ b/torch_geometric/transforms/local_cartesian.py
@@ -8,25 +8,29 @@ class LocalCartesian(object):
     interval :math:`{[0, 1]}^D`.
 
     Args:
+        norm (bool, optional): If set to :obj:`False`, the output will not be
+            normalized to the interval :math:`{[0, 1]}^D`.
+            (default: :obj:`True`)
         cat (bool, optional): If set to :obj:`False`, all existing edge
             attributes will be replaced. (default: :obj:`True`)
-        normalization (bool, optional): If set to :obj:`False`, 
-            normalization is disabled. (default: :obj:`True`)
     """
-    def __init__(self, cat=True, normalization=True):
+    def __init__(self, norm=True, cat=True):
+        self.norm = norm
         self.cat = cat
-        self.normalization = normalization
 
     def __call__(self, data):
         (row, col), pos, pseudo = data.edge_index, data.pos, data.edge_attr
 
         cart = pos[row] - pos[col]
         cart = cart.view(-1, 1) if cart.dim() == 1 else cart
-        
-        if self.normalization:
-            max_value, _ = scatter_max(cart.abs(), col, 0, dim_size=pos.size(0))
-            max_value = max_value.max(dim=-1, keepdim=True)[0]
+
+        max_value, _ = scatter_max(cart.abs(), col, 0, dim_size=pos.size(0))
+        max_value = max_value.max(dim=-1, keepdim=True)[0]
+
+        if self.norm:
             cart = cart / (2 * max_value[col]) + 0.5
+        else:
+            cart = cart / max_value[col]
 
         if pseudo is not None and self.cat:
             pseudo = pseudo.view(-1, 1) if pseudo.dim() == 1 else pseudo


### PR DESCRIPTION
This is a small PR:
* LocalCartesian: The normalization is now optional
* LocalCartesian: I changed `cart = pos[col] - pos[row]` into `cart = pos[row] - pos[col]` because it is usually x_j - x_i (position of neighbor - position of central point)
* GMMConv: Add a note that points to LocalCartesian