### PR TITLE
Added a flag to gnn_explainer.

### DIFF
--- a/examples/gnn_explainer.py
+++ b/examples/gnn_explainer.py
@@ -40,7 +40,7 @@ for epoch in range(1, 201):
     loss.backward()
     optimizer.step()
 
-explainer = GNNExplainer(model, epochs=200)
+explainer = GNNExplainer(model, epochs=200, return_type='log_prob')
 node_idx = 10
 node_feat_mask, edge_mask = explainer.explain_node(node_idx, x, edge_index)
 ax, G = explainer.visualize_subgraph(node_idx, edge_index, edge_mask, y=data.y)

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -53,17 +53,14 @@ def test_gnn_explainer(model):
 
 
 @pytest.mark.parametrize('model', [GCN(), GAT()])
-def test_to_log_proba(model):
-    raw_to_log = GNNExplainer(model, return_type='raw').to_log_proba
-    proba_to_log = GNNExplainer(model, return_type='proba').to_log_proba
-    log_to_log = GNNExplainer(model).to_log_proba
+def test_to_log_prob(model):
+    raw_to_log = GNNExplainer(model, return_type='raw').__to_log_prob__
+    prob_to_log = GNNExplainer(model, return_type='prob').__to_log_prob__
+    log_to_log = GNNExplainer(model, return_type='log_prob').__to_log_prob__
 
     raw = torch.tensor([[1, 3.2, 6.1], [9, 9, 0.1]])
-    proba = raw.softmax(dim=-1)
-    log = raw.log_softmax(dim=-1)
+    prob = raw.softmax(dim=-1)
+    log_prob = raw.log_softmax(dim=-1)
 
-    assert torch.allclose(raw_to_log(raw), proba_to_log(proba))
-    assert torch.allclose(proba_to_log(proba), log_to_log(log))
-
-    with pytest.raises(AssertionError):
-        GNNExplainer(model, return_type='dummy')
+    assert torch.allclose(raw_to_log(raw), prob_to_log(prob))
+    assert torch.allclose(prob_to_log(prob), log_to_log(log_prob))

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -50,3 +50,20 @@ def test_gnn_explainer(model):
     explainer.visualize_subgraph(2, edge_index, edge_mask, threshold=0.5)
     explainer.visualize_subgraph(2, edge_index, edge_mask, y=y, threshold=None)
     explainer.visualize_subgraph(2, edge_index, edge_mask, y=y, threshold=0.5)
+
+
+@pytest.mark.parametrize('model', [GCN(), GAT()])
+def test_to_log_proba(model):
+    raw_to_log = GNNExplainer(model, return_type='raw').to_log_proba
+    proba_to_log = GNNExplainer(model, return_type='proba').to_log_proba
+    log_to_log = GNNExplainer(model).to_log_proba
+
+    raw = torch.tensor([[1, 3.2, 6.1], [9, 9, 0.1]])
+    proba = raw.softmax(dim=-1)
+    log = raw.log_softmax(dim=-1)
+
+    assert torch.allclose(raw_to_log(raw), proba_to_log(proba))
+    assert torch.allclose(proba_to_log(proba), log_to_log(log))
+
+    with pytest.raises(AssertionError):
+        GNNExplainer(model, return_type='dummy')

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -37,12 +37,11 @@ class GNNExplainer(torch.nn.Module):
             information based on the number of
             :class:`~torch_geometric.nn.conv.message_passing.MessagePassing`
             layers inside :obj:`model`. (default: :obj:`None`)
-        return_type (str, optional): valid inputs are log_proba,raw,and proba.
-            Set to
-            log_proba: if :obj:`model` returns log of probability.
-            raw: if :obj:`model` returns raw scores.
-            proba: if :obj:`model` returns pobability of each class.
-            (default: :obj:`"log_proba"`)
+        return_type (str, optional): Denotes the type of output from
+            :obj:`model`. Valid inputs are :obj:`"log_prob"` (the model returns
+            the logarithm of probabilities), :obj:`"prob"` (the model returns
+            probabilities) and :obj:`"raw"` (the model returns raw scores).
+            (default: :obj:`"log_prob"`)
         log (bool, optional): If set to :obj:`False`, will not log any learning
             progress. (default: :obj:`True`)
     """
@@ -57,17 +56,15 @@ class GNNExplainer(torch.nn.Module):
     }
 
     def __init__(self, model, epochs: int = 100, lr: float = 0.01,
-                 num_hops: Optional[int] = None,
-                 return_type: str = 'log_proba', log: bool = True):
+                 num_hops: Optional[int] = None, return_type: str = 'log_prob',
+                 log: bool = True):
         super(GNNExplainer, self).__init__()
+        assert return_type in ['log_prob', 'prob', 'raw']
         self.model = model
         self.epochs = epochs
         self.lr = lr
         self.__num_hops__ = num_hops
-
-        assert return_type in ['log_proba', 'raw', 'proba']
         self.return_type = return_type
-
         self.log = log
 
     def __set_masks__(self, x, edge_index, init="normal"):
@@ -143,19 +140,10 @@ class GNNExplainer(torch.nn.Module):
 
         return loss
 
-    def to_log_proba(self, output: torch.Tensor):
-        r"""converts model output from raw scores or probabilities to
-        log of probability
-
-        :rtype: (:class:`Tensor`)
-        """
-        if self.return_type == 'log_proba':
-            return output
-        elif self.return_type == 'raw':
-            # features are assumed to be the last dimension.
-            return output.log_softmax(dim=-1)
-        else:
-            return output.log()
+    def __to_log_prob__(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.log_softmax(dim=-1) if self.return_type == 'raw' else x
+        x = x.log() if self.return_type == 'prob' else x
+        return x
 
     def explain_node(self, node_idx, x, edge_index, **kwargs):
         r"""Learns and returns a node feature mask and an edge mask that play a
@@ -182,8 +170,8 @@ class GNNExplainer(torch.nn.Module):
 
         # Get the initial prediction.
         with torch.no_grad():
-            output = self.model(x=x, edge_index=edge_index, **kwargs)
-            log_logits = self.to_log_proba(output)
+            out = self.model(x=x, edge_index=edge_index, **kwargs)
+            log_logits = self.__to_log_prob__(out)
             pred_label = log_logits.argmax(dim=-1)
 
         self.__set_masks__(x, edge_index)
@@ -199,8 +187,8 @@ class GNNExplainer(torch.nn.Module):
         for epoch in range(1, self.epochs + 1):
             optimizer.zero_grad()
             h = x * self.node_feat_mask.view(1, -1).sigmoid()
-            output = self.model(x=h, edge_index=edge_index, **kwargs)
-            log_logits = self.to_log_proba(output)
+            out = self.model(x=h, edge_index=edge_index, **kwargs)
+            log_logits = self.__to_log_prob__(out)
             loss = self.__loss__(mapping, log_logits, pred_label)
             loss.backward()
             optimizer.step()


### PR DESCRIPTION
#2203. 

 Made changes to.
- gnn_explainer.py
- - Added a flag called `retrun_type` to gnn_explainer. This flag indicates if the model will output raw scores, probabilities or log of probability.
- - Within the `explian_node` module model outputs are converted to log of probability based on the flag. `to_log_proba` is used to convert outputs.
- test_gnn_explainer.py: Add a new test function to test `to_log_proba`