### PR TITLE
Add FAQ about setting CUDA_HOME.

### DIFF
--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -176,3 +176,9 @@ Frequently Asked Questions
 
 #. On macOS: ``The version of the host compiler ('Apple clang') is not supported``: Downgrade your command line tools (see `this StackOverflow thread <https://stackoverflow.com/questions/36250949/revert-apple-clang-version-for-nvcc/46574116>`_) with the respective version annotated in the `CUDA Installation Guide for Mac <https://developer.download.nvidia.com/compute/cuda/10.1/Prod/docs/sidebar/CUDA_Installation_Guide_Mac.pdf>`_ (Section 1.1) for your specific CUDA version.
    You can download previous command line tool versions `here <https://idmsa.apple.com/IDMSWebAuth/signin?appIdKey=891bd3417a7776362562d2197f89480a8547b108fd934911bcbea0110d07f757&path=%2Fdownload%2Fmore%2F&rv=1>`_.
+
+#. On Linux: ``nvcc fatal   : Path to libdevice library not specified`` appears even if ``LD_LIBRARY_PATH`` and ``CPATH`` are set correctly. The library will be found if ``$CUDA_HOME`` is defined:
+
+    .. code-block:: none
+    
+        $ export CUDA_HOME=/usr/local/cuda

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -177,7 +177,7 @@ Frequently Asked Questions
 #. On macOS: ``The version of the host compiler ('Apple clang') is not supported``: Downgrade your command line tools (see `this StackOverflow thread <https://stackoverflow.com/questions/36250949/revert-apple-clang-version-for-nvcc/46574116>`_) with the respective version annotated in the `CUDA Installation Guide for Mac <https://developer.download.nvidia.com/compute/cuda/10.1/Prod/docs/sidebar/CUDA_Installation_Guide_Mac.pdf>`_ (Section 1.1) for your specific CUDA version.
    You can download previous command line tool versions `here <https://idmsa.apple.com/IDMSWebAuth/signin?appIdKey=891bd3417a7776362562d2197f89480a8547b108fd934911bcbea0110d07f757&path=%2Fdownload%2Fmore%2F&rv=1>`_.
 
-#. On Linux: ``nvcc fatal   : Path to libdevice library not specified`` appears even if ``LD_LIBRARY_PATH`` and ``CPATH`` are set correctly. The library will be found if ``$CUDA_HOME`` is defined:
+#. On Linux: ``nvcc fatal   : Path to libdevice library not specified`` appears even if ``LD_LIBRARY_PATH`` and ``CPATH`` are set correctly. As recommended by `this post <https://askubuntu.com/a/1298665>`__, the library will be found if ``$CUDA_HOME`` is defined:
 
     .. code-block:: none
     

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -177,8 +177,9 @@ Frequently Asked Questions
 #. On macOS: ``The version of the host compiler ('Apple clang') is not supported``: Downgrade your command line tools (see `this StackOverflow thread <https://stackoverflow.com/questions/36250949/revert-apple-clang-version-for-nvcc/46574116>`_) with the respective version annotated in the `CUDA Installation Guide for Mac <https://developer.download.nvidia.com/compute/cuda/10.1/Prod/docs/sidebar/CUDA_Installation_Guide_Mac.pdf>`_ (Section 1.1) for your specific CUDA version.
    You can download previous command line tool versions `here <https://idmsa.apple.com/IDMSWebAuth/signin?appIdKey=891bd3417a7776362562d2197f89480a8547b108fd934911bcbea0110d07f757&path=%2Fdownload%2Fmore%2F&rv=1>`_.
 
-#. On Linux: ``nvcc fatal   : Path to libdevice library not specified`` appears even if ``LD_LIBRARY_PATH`` and ``CPATH`` are set correctly. As recommended by `this post <https://askubuntu.com/a/1298665>`__, the library will be found if ``$CUDA_HOME`` is defined:
+#. On Linux: ``nvcc fatal: Path to libdevice library not specified``: This error may appear even if ``LD_LIBRARY_PATH`` and ``CPATH`` are set up correctly.
+   As recommended by `this post <https://askubuntu.com/a/1298665>`__, the library will be found if ``$CUDA_HOME`` is defined:
 
     .. code-block:: none
-    
+
         $ export CUDA_HOME=/usr/local/cuda


### PR DESCRIPTION
I added a FAQ entry for fixing an installation issue I saw on my machine. This issue was observed in a conda environment running on Windows Subsystem for Linux with Ubuntu 20.04, CUDA 11.0, and PyTorch 1.8.0. (I was building from source because there are currently no wheels provided for this combination of CUDA and PyTorch versions).

See this page for the source of the fix: https://askubuntu.com/questions/1254849/nvcc-fatal-path-to-libdevice-library-not-specified