### PR TITLE
fixed bug in kl_loss.

### DIFF
--- a/torch_geometric/nn/pool/mem_pool.py
+++ b/torch_geometric/nn/pool/mem_pool.py
@@ -68,7 +68,7 @@ class MemPooling(torch.nn.Module):
         """
         S_2 = S**2
         P = S_2 / S.sum(dim=1, keepdim=True)
-        P = P / (S_2.sum(dim=2, keepdim=True) / S.sum(dim=1, keepdim=True))
+        P = P / P.sum(dim=2, keepdim=True)
         P[torch.isnan(P)] = 0.
 
         loss = KLDivLoss(reduction='batchmean', log_target=False)


### PR DESCRIPTION

Changed this line `P = P / (S_2.sum(dim=2, keepdim=True) / S.sum(dim=1, keepdim=True))`, to 
`P=P/P.sum(2,keepdim=True)` in kl_loss in mem_pool.py.
Posting the equation from the paper. In the denominator the inner summation is inside the outer summation.  The equation is probably confusing as  bracket are missing after the outer summation.

![image](https://user-images.githubusercontent.com/13963626/111269427-a3e4fc80-8654-11eb-9731-a2a8f74b80a4.png)

Also pasting an image from the original [paper](https://arxiv.org/pdf/1511.06335.pdf) that proposed this metric. Here the equation is clearer.
![image](https://user-images.githubusercontent.com/13963626/112645066-1da69280-8e6c-11eb-8a34-18d45a199067.png)
