### PR TITLE
Homophilyfix.

### DIFF
--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -1,0 +1,9 @@
+import torch
+from torch_geometric.utils import homophily
+
+
+def test_homophily():
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
+    y = torch.tensor([0, 0, 0])
+    assert homophily(edge_index, y, method='edge') == 1.
+    assert homophily(edge_index, y.unsqueeze(1), method='node') == 1.

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -64,6 +64,6 @@ def homophily(edge_index: Adj, y: Tensor, method: str = 'edge'):
         return int((y[row] == y[col]).sum()) / row.size(0)
     else:
         out = torch.zeros_like(row, dtype=float)
-        out[y[row] == y[col]] = 1.
+        out[(y[row] == y[col]).squeeze()] = 1.
         out = scatter_mean(out, col, 0, dim_size=y.size(0))
         return float(out.mean())


### PR DESCRIPTION
An error shows up while measuring homophily on the arxiv dataset. Check code and error below.
```
dataset=PygNodePropPredDataset(name='ogbn-arxiv',root='../node_dataset/')
split_idx = dataset.get_idx_split()
data = dataset[0]
data.y.shape # [169343, 1]
homophily(data.edge_index,data.y,method="node")
```
```
<ipython-input-121-3e87edc6610c> in homophily(edge_index, y, method)
     65     else:
     66         out = torch.zeros_like(row, dtype=float)
---> 67         out[(y[row] == y[col])] = 1.
     68         out = scatter_mean(out, col, 0, dim_size=y.size(0))
     69         return float(out.mean())

IndexError: too many indices for tensor of dimension 1
```
This PR has 2 changes.
1. fixes the error .
2. Adds a test for homophily.
