### PR TITLE
Changes lambda collate_fn to static method for DataListLoader

### DIFF
--- a/torch_geometric/data/dataloader.py
+++ b/torch_geometric/data/dataloader.py
@@ -88,7 +88,11 @@ class DataListLoader(torch.utils.data.DataLoader):
     def __init__(self, dataset, batch_size=1, shuffle=False, **kwargs):
         super(DataListLoader,
               self).__init__(dataset, batch_size, shuffle,
-                             collate_fn=lambda data_list: data_list, **kwargs)
+                             collate_fn=self.collate_fn, **kwargs)
+
+    @staticmethod
+    def collate_fn(data_list):
+        return data_list
 
 
 class DenseCollater(object):

--- a/torch_geometric/data/dataloader.py
+++ b/torch_geometric/data/dataloader.py
@@ -69,6 +69,10 @@ class DataLoader(torch.utils.data.DataLoader):
                                                  exclude_keys), **kwargs)
 
 
+ def identity_collate(data_list):
+     return data_list
+
+
 class DataListLoader(torch.utils.data.DataLoader):
     r"""Data loader which merges data objects from a
     :class:`torch_geometric.data.dataset` to a python list.
@@ -88,11 +92,7 @@ class DataListLoader(torch.utils.data.DataLoader):
     def __init__(self, dataset, batch_size=1, shuffle=False, **kwargs):
         super(DataListLoader,
               self).__init__(dataset, batch_size, shuffle,
-                             collate_fn=self.collate_fn, **kwargs)
-
-    @staticmethod
-    def collate_fn(data_list):
-        return data_list
+                             collate_fn=identity_collate, **kwargs)
 
 
 class DenseCollater(object):


### PR DESCRIPTION
Since lambda functions can't be pickled on Windows (for multiprocessing), instead users can provide their own collate function.
This would be a preferable solution. Alternatively, one could add a functional identity function:

```python
def identity(x):
    return x
```

and set `collate_fn=identity`.