### PR TITLE
Index select type issue

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -204,7 +204,7 @@ class Dataset(torch.utils.data.Dataset):
             elif idx.dtype == torch.bool or idx.dtype == torch.uint8:
                 return self.index_select(
                     idx.nonzero(as_tuple=False).flatten().tolist())
-        elif isinstance(idx, list) or isinstance(idx, tuple):
+        elif isinstance(idx, (list, tuple, np.ndarray)):
             indices = [indices[i] for i in idx]
         else:
             raise IndexError(

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -1,6 +1,7 @@
 import re
 import copy
 import logging
+import numpy as np
 import os.path as osp
 
 import torch.utils.data
@@ -183,7 +184,7 @@ class Dataset(torch.utils.data.Dataset):
         In case :obj:`idx` is a slicing object, *e.g.*, :obj:`[2:5]`, a list, a
         tuple, a  LongTensor or a BoolTensor, will return a subset of the
         dataset at the specified indices."""
-        if isinstance(idx, int):
+        if isinstance(idx, (int, np.integer)):
             data = self.get(self.indices()[idx])
             data = data if self.transform is None else self.transform(data)
             return data


### PR DESCRIPTION
When selecting an index from a dataset, the original repo requires an integer, slice, tuple, tensor or a list:

```python
import numpy as np
from torch_geometric.datasets import TUDataset
tu_dataset = TUDataset(root='~/notebooks/tmp/ENZYMES', name='ENZYMES')

idx = 0
tu_dataset[idx]
>>> Data(edge_index=[2, 168], x=[37, 3], y=[1])
```

However, when using numpy integers like `np.int32`, it breaks:

```python
idx = np.int32(0)
tu_dataset[idx]
>>>IndexError: Only integers, slices (`:`), list, tuples, and long or bool tensors are valid indices (got int32).
```

This PR fixes it:

```python
idx = np.int32(0)
tu_dataset[idx]
>>> Data(edge_index=[2, 168], x=[37, 3], y=[1])
```

It is also now possible to pass numpy arrays as indices:

```python
idx = np.arange(10)
tu_dataset[idx]
>>>ENZYMES(10)
```
