### PR TITLE
Gnnexplainer graph-explanation fix.

### DIFF
--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -98,6 +98,8 @@ def test_graph_explainer(model):
 
     node_feat_mask, edge_mask = explainer.explain_graph(x, edge_index)
     assert_edgemask_clear(model)
+    _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask,
+                                        y=torch.tensor(2), threshold=0.8)
     assert node_feat_mask.size() == (x.size(1), )
     assert node_feat_mask.min() >= 0 and node_feat_mask.max() <= 1
     assert edge_mask.shape[0] == edge_index.shape[1]

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -276,7 +276,8 @@ class GNNExplainer(torch.nn.Module):
             edge_index (LongTensor): The edge indices.
             edge_mask (Tensor): The edge mask.
             y (Tensor, optional): The ground-truth node-prediction labels used
-                as node colorings. (default: :obj:`None`)
+                as node colorings. All nodes will have the same color
+                if :attr:`node_idx` is :obj:`-1`.(default: :obj:`None`).
             threshold (float, optional): Sets a threshold for visualizing
                 important edges. If set to :obj:`None`, will visualize all
                 edges with transparancy indicating the importance of edges.
@@ -292,9 +293,10 @@ class GNNExplainer(torch.nn.Module):
         if node_idx == -1:
             hard_edge_mask = torch.BoolTensor([True] * edge_index.size(1),
                                               device=edge_mask.device)
-            subset = torch.arange(
-                edge_index.max() + 1,
-                device=edge_index.device if y is None else y.device)
+            subset = torch.arange(edge_index.max().item() + 1,
+                                  device=edge_index.device)
+            y = None
+
         else:
             # Only operate on a k-hop subgraph around `node_idx`.
             subset, edge_index, _, hard_edge_mask = k_hop_subgraph(


### PR DESCRIPTION
**Bug**

  ```
  explainer = GNNExplainer(model, epochs=200)
  explainer.explain_graph(x, edge_index) 
  explainer.visualize_subgraph(node_idx=-1,edge_index, edge_mask, y=torch.tensor(4))
  ```
Running above code throws `IndexError: too many indices for tensor of dimension 0` at ` y = y[subset].to(torch.float) / y.max().item()` inside visualize_subgraph.

**Fix**

`y` is set to `None` inside `visualize_subgraph` for graph explanation task. And all nodes will have the same color in this case.

Thanks @Luoyunsong for bringing [this](https://github.com/rusty1s/pytorch_geometric/pull/2597#issuecomment-845175664) up.