### PR TITLE
Add more NumPy indexing and allow negative indices in Batch

### DIFF
--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -226,13 +226,17 @@ class Batch(Data):
             if idx.dtype == torch.bool:
                 idx = idx.nonzero(as_tuple=False).view(-1)
             idx = idx.tolist()
-        elif isinstance(idx, (list, tuple, np.ndarray)):
+        elif isinstance(idx, np.ndarray):
+            if idx.dtype == np.bool:
+                idx = np.stack(idx.nonzero()).transpose().reshape(-1)
+            idx = idx.tolist()
+        elif isinstance(idx, (list, tuple)):
             pass
         else:
             raise IndexError(
-                'Only integers, slices (`:`), list, tuples, numpy arrays and '
-                'long or bool tensors are valid indices (got {}).'.format(
-                    type(idx).__name__))
+                'Only integers, slices (`:`), list, tuples, bool or long or '
+                'int numpy arrays and long or bool tensors are valid indices '
+                '(got {}).'.format(type(idx).__name__))
 
         return [self.get_example(i) for i in idx]
 

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -208,8 +208,8 @@ class Dataset(torch.utils.data.Dataset):
             indices = [indices[i] for i in idx]
         else:
             raise IndexError(
-                'Only integers, slices (`:`), list, tuples, and long or bool '
-                'tensors are valid indices (got {}).'.format(
+                'Only integers, slices (`:`), list, tuples, numpy arrays and '
+                'long or bool tensors are valid indices (got {}).'.format(
                     type(idx).__name__))
 
         dataset = copy.copy(self)

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -204,13 +204,21 @@ class Dataset(torch.utils.data.Dataset):
             elif idx.dtype == torch.bool or idx.dtype == torch.uint8:
                 return self.index_select(
                     idx.nonzero(as_tuple=False).flatten().tolist())
+        elif isinstance(idx, np.ndarray):
+            if idx.dtype != np.bool:
+                if len(idx.shape) == 0:
+                    idx = np.expand_dims(idx, 0)
+                return self.index_select(idx.tolist())
+            elif idx.dtype == np.bool:
+                return self.index_select(
+                    np.stack(idx.nonzero()).transpose().reshape(-1).tolist())
         elif isinstance(idx, (list, tuple, np.ndarray)):
             indices = [indices[i] for i in idx]
         else:
             raise IndexError(
-                'Only integers, slices (`:`), list, tuples, numpy arrays and '
-                'long or bool tensors are valid indices (got {}).'.format(
-                    type(idx).__name__))
+                'Only integers, slices (`:`), list, tuples, bool or long or '
+                'intnumpy arrays and long or bool tensors are valid indices '
+                '(got {}).'.format(type(idx).__name__))
 
         dataset = copy.copy(self)
         dataset.__indices__ = indices


### PR DESCRIPTION
This PR has three different parts:

1. Extend NumPy arrays indexing for Dataset. It is now possible to use ``bool`` NumPy arrays, similarly to tensors:

```python
import numpy as np
from torch_geometric.datasets import TUDataset

dataset = TUDataset(root='~/notebooks/tmp/ENZYMES', name='ENZYMES')
idx = np.arange(5).astype('bool')
dataset[idx]
>>> ENZYMES(4)
```

2. Add NumPy arrays indexing to Batch, similarly to Dataset:

```python
 from torch_geometric.data import Batch

idx = np.arange(5)
Batch.from_data_list([dataset[i] for i in range(10)])[idx]
>>> [Data(edge_index=[2, 168], x=[37, 3], y=[1]),
...     Data(edge_index=[2, 102], x=[23, 3], y=[1]),
...     Data(edge_index=[2, 92], x=[25, 3], y=[1]),
...     Data(edge_index=[2, 90], x=[24, 3], y=[1]),
...     Data(edge_index=[2, 90], x=[23, 3], y=[1])]
```

3. Allow negative indices for Batch:

```python
batch = Batch.from_data_list([dataset[i] for i in range(10)])
batch[-1]
>>> Data(edge_index=[2, 106], x=[32, 3], y=[1])
```

The range of allowed indices is [-n, n-1] for a Batch of size n, similarly to tensors.