### PR TITLE
Fix to `test` in proteins_mincut_pool.py 

### DIFF
--- a/examples/proteins_mincut_pool.py
+++ b/examples/proteins_mincut_pool.py
@@ -84,14 +84,16 @@ def train(epoch):
 def test(loader):
     model.eval()
     correct = 0
-
+    loss_all = 0
+	
     for data in loader:
         data = data.to(device)
         pred, mc_loss, o_loss = model(data.x, data.edge_index, data.batch)
         loss = F.nll_loss(pred, data.y.view(-1)) + mc_loss + o_loss
+        loss_all += data.y.size(0) * loss.item()        
         correct += pred.max(dim=1)[1].eq(data.y.view(-1)).sum().item()
 
-    return loss, correct / len(loader.dataset)
+    return loss_all /len(loader.dataset), correct / len(loader.dataset)
 
 
 best_val_acc = test_acc = 0

--- a/examples/proteins_mincut_pool.py
+++ b/examples/proteins_mincut_pool.py
@@ -85,15 +85,15 @@ def test(loader):
     model.eval()
     correct = 0
     loss_all = 0
-	
+
     for data in loader:
         data = data.to(device)
         pred, mc_loss, o_loss = model(data.x, data.edge_index, data.batch)
         loss = F.nll_loss(pred, data.y.view(-1)) + mc_loss + o_loss
-        loss_all += data.y.size(0) * loss.item()        
+        loss_all += data.y.size(0) * loss.item()
         correct += pred.max(dim=1)[1].eq(data.y.view(-1)).sum().item()
 
-    return loss_all /len(loader.dataset), correct / len(loader.dataset)
+    return loss_all / len(loader.dataset), correct / len(loader.dataset)
 
 
 best_val_acc = test_acc = 0


### PR DESCRIPTION
Bug: The `test` function in [proteins_mincut_pool.py](https://github.com/rusty1s/pytorch_geometric/blob/a17f81217f043bb9d97eca83e1b671b5f48e0ae6/examples/proteins_mincut_pool.py#L91)  returns loss of the last batch. 
Fix: `test` now returns average loss across all batches.