### PR TITLE
Error when computing num_graphs

### DIFF
--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -271,7 +271,7 @@ class Batch(Data):
         if self.__num_graphs__ is not None:
             return self.__num_graphs__
         elif self.ptr is not None:
-            return self.ptr.numel() + 1
+            return self.ptr.numel() - 1
         elif self.batch is not None:
             return int(self.batch.max()) + 1
         else:


### PR DESCRIPTION
Num graphs inconsistent in Batch:

```python
from torch_geometric.data import Batch
from torch_geometric.datasets import TUDataset

dataset = TUDataset(root='~/notebooks/tmp/ENZYMES', name='ENZYMES')
batch = Batch.from_data_list([dataset[i] for i in range(10)])

batch.__num_graphs__
>>> 10

batch.ptr.numel() + 1
>>> 12

int(batch.batch.max()) + 1
>>> 10
```

This PR replaces ``batch.ptr.numel() + 1`` with ``batch.ptr.numel() - 1``
