### PR TITLE
Add split functionality for edge attributes

### DIFF
--- a/test/utils/test_train_test_split_edges.py
+++ b/test/utils/test_train_test_split_edges.py
@@ -7,10 +7,12 @@ from torch_geometric.utils import train_test_split_edges
 def test_train_test_split_edges():
     edge_index = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
-    data = Data(edge_index=edge_index)
+    edge_attr = torch.arange(edge_index.size(1))
+    data = Data(edge_index=edge_index, edge_attr=edge_attr)
     data.num_nodes = edge_index.max().item() + 1
     data = train_test_split_edges(data, val_ratio=0.2, test_ratio=0.3)
 
+    assert len(data) == 9
     assert data.val_pos_edge_index.size() == (2, 2)
     assert data.val_neg_edge_index.size() == (2, 2)
     assert data.test_pos_edge_index.size() == (2, 3)
@@ -18,3 +20,6 @@ def test_train_test_split_edges():
     assert data.train_pos_edge_index.size() == (2, 10)
     assert data.train_neg_adj_mask.size() == (11, 11)
     assert data.train_neg_adj_mask.sum().item() == (11**2 - 11) / 2 - 4 - 6 - 5
+    assert data.train_pos_edge_attr.size() == (10, )
+    assert data.val_pos_edge_attr.size() == (2, )
+    assert data.test_pos_edge_attr.size() == (3, )

--- a/torch_geometric/utils/train_test_split_edges.py
+++ b/torch_geometric/utils/train_test_split_edges.py
@@ -1,17 +1,18 @@
 import math
+
 import torch
-from torch_geometric.data import Data
+
 from torch_geometric.utils import to_undirected
 
 
-def train_test_split_edges(data: Data, val_ratio: float = 0.05,
-                           test_ratio: float = 0.1) -> Data:
+def train_test_split_edges(data, val_ratio: float = 0.05,
+                           test_ratio: float = 0.1):
     r"""Splits the edges of a :class:`torch_geometric.data.Data` object
     into positive and negative train/val/test edges.
     As such, it will replace the :obj:`edge_index` attribute with
     :obj:`train_pos_edge_index`, :obj:`train_pos_neg_adj_mask`,
     :obj:`val_pos_edge_index`, :obj:`val_neg_edge_index` and
-    :obj:`test_pos_edge_index`.
+    :obj:`test_pos_edge_index` attributes.
     If :obj:`data` has edge features named :obj:`edge_attr`, then
     :obj:`train_pos_edge_attr`, :obj:`val_pos_edge_attr` and
     :obj:`test_pos_edge_attr` will be added as well.
@@ -22,9 +23,6 @@ def train_test_split_edges(data: Data, val_ratio: float = 0.05,
             (default: :obj:`0.05`)
         test_ratio (float, optional): The ratio of positive test edges.
             (default: :obj:`0.1`)
-        add_train_neg_mask (bool, optional): If set to :obj:`True`, will add a
-            :obj:`train_neg_adj_mask` attribute to the :obj:`data` object that
-            can be used for negative sampling. (default: :obj:`True`)
 
     :rtype: :class:`torch_geometric.data.Data`
     """
@@ -34,7 +32,7 @@ def train_test_split_edges(data: Data, val_ratio: float = 0.05,
     num_nodes = data.num_nodes
     row, col = data.edge_index
     edge_attr = data.edge_attr
-    data.edge_index, data.edge_attr = None
+    data.edge_index = data.edge_attr = None
 
     # Return upper triangular portion.
     mask = row < col

--- a/torch_geometric/utils/train_test_split_edges.py
+++ b/torch_geometric/utils/train_test_split_edges.py
@@ -1,21 +1,31 @@
 import math
 import torch
+from torch_geometric.data import Data
 from torch_geometric.utils import to_undirected
 
 
-def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
-    r"""Splits the edges of a :obj:`torch_geometric.data.Data` object
-    into positive and negative train/val/test edges, and adds attributes of
-    `train_pos_edge_index`, `train_neg_adj_mask`, `val_pos_edge_index`,
-    `val_neg_edge_index`, `test_pos_edge_index`, and `test_neg_edge_index`
-    to :attr:`data`. If `data` has `edge_attr`, `train_pos_edge_attr`,
-    `val_pos_edge_attr` and `test_pos_edge_attr` are also added.
+def train_test_split_edges(data: Data, val_ratio: float = 0.05,
+                           test_ratio: float = 0.1) -> Data:
+    r"""Splits the edges of a :class:`torch_geometric.data.Data` object
+    into positive and negative train/val/test edges.
+    As such, it will replace the :obj:`edge_index` attribute with
+    :obj:`train_pos_edge_index`, :obj:`train_pos_neg_adj_mask`,
+    :obj:`val_pos_edge_index`, :obj:`val_neg_edge_index` and
+    :obj:`test_pos_edge_index`.
+    If :obj:`data` has edge features named :obj:`edge_attr`, then
+    :obj:`train_pos_edge_attr`, :obj:`val_pos_edge_attr` and
+    :obj:`test_pos_edge_attr` will be added as well.
+
     Args:
         data (Data): The data object.
-        val_ratio (float, optional): The ratio of positive validation
-            edges. (default: :obj:`0.05`)
-        test_ratio (float, optional): The ratio of positive test
-            edges. (default: :obj:`0.1`)
+        val_ratio (float, optional): The ratio of positive validation edges.
+            (default: :obj:`0.05`)
+        test_ratio (float, optional): The ratio of positive test edges.
+            (default: :obj:`0.1`)
+        add_train_neg_mask (bool, optional): If set to :obj:`True`, will add a
+            :obj:`train_neg_adj_mask` attribute to the :obj:`data` object that
+            can be used for negative sampling. (default: :obj:`True`)
+
     :rtype: :class:`torch_geometric.data.Data`
     """
 
@@ -23,15 +33,15 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
 
     num_nodes = data.num_nodes
     row, col = data.edge_index
-    attr = data.edge_attr
-    data.edge_index = None
+    edge_attr = data.edge_attr
+    data.edge_index, data.edge_attr = None
 
     # Return upper triangular portion.
     mask = row < col
     row, col = row[mask], col[mask]
 
-    if attr is not None:
-      attr = attr[mask]
+    if edge_attr is not None:
+        edge_attr = edge_attr[mask]
 
     n_v = int(math.floor(val_ratio * row.size(0)))
     n_t = int(math.floor(test_ratio * row.size(0)))
@@ -39,29 +49,27 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
     # Positive edges.
     perm = torch.randperm(row.size(0))
     row, col = row[perm], col[perm]
-    if attr is not None:
-      attr = attr[perm]
+    if edge_attr is not None:
+        edge_attr = edge_attr[perm]
 
     r, c = row[:n_v], col[:n_v]
     data.val_pos_edge_index = torch.stack([r, c], dim=0)
-    if attr is not None:
-      a = attr[:n_v]
-      data.val_pos_edge_attr = a
+    if edge_attr is not None:
+        data.val_pos_edge_attr = edge_attr[:n_v]
 
     r, c = row[n_v:n_v + n_t], col[n_v:n_v + n_t]
     data.test_pos_edge_index = torch.stack([r, c], dim=0)
-    if attr is not None:
-      a = attr[n_v:n_v + n_t]
-      data.test_pos_edge_attr = a
+    if edge_attr is not None:
+        data.test_pos_edge_attr = edge_attr[n_v:n_v + n_t]
 
     r, c = row[n_v + n_t:], col[n_v + n_t:]
     data.train_pos_edge_index = torch.stack([r, c], dim=0)
-    if attr is not None:
-      a = attr[n_v + n_t:]
-      data.train_pos_edge_index, data.train_pos_edge_attr = to_undirected(data.train_pos_edge_index, a)
+    if edge_attr is not None:
+        out = to_undirected(data.train_pos_edge_index, edge_attr[n_v + n_t:])
+        data.train_pos_edge_index, data.train_pos_edge_attr = out
     else:
-      data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
-   
+        data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
+
     # Negative edges.
     neg_adj_mask = torch.ones(num_nodes, num_nodes, dtype=torch.uint8)
     neg_adj_mask = neg_adj_mask.triu(diagonal=1).to(torch.bool)

--- a/torch_geometric/utils/train_test_split_edges.py
+++ b/torch_geometric/utils/train_test_split_edges.py
@@ -8,15 +8,14 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
     into positive and negative train/val/test edges, and adds attributes of
     `train_pos_edge_index`, `train_neg_adj_mask`, `val_pos_edge_index`,
     `val_neg_edge_index`, `test_pos_edge_index`, and `test_neg_edge_index`
-    to :attr:`data`.
-
+    to :attr:`data`. If `data` has `edge_attr`, `train_pos_edge_attr`,
+    `val_pos_edge_attr` and `test_pos_edge_attr` are also added.
     Args:
         data (Data): The data object.
         val_ratio (float, optional): The ratio of positive validation
             edges. (default: :obj:`0.05`)
         test_ratio (float, optional): The ratio of positive test
             edges. (default: :obj:`0.1`)
-
     :rtype: :class:`torch_geometric.data.Data`
     """
 
@@ -24,11 +23,15 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
 
     num_nodes = data.num_nodes
     row, col = data.edge_index
+    attr = data.edge_attr
     data.edge_index = None
 
     # Return upper triangular portion.
     mask = row < col
     row, col = row[mask], col[mask]
+
+    if attr is not None:
+      attr = attr[mask]
 
     n_v = int(math.floor(val_ratio * row.size(0)))
     n_t = int(math.floor(test_ratio * row.size(0)))
@@ -36,16 +39,29 @@ def train_test_split_edges(data, val_ratio=0.05, test_ratio=0.1):
     # Positive edges.
     perm = torch.randperm(row.size(0))
     row, col = row[perm], col[perm]
+    if attr is not None:
+      attr = attr[perm]
 
     r, c = row[:n_v], col[:n_v]
     data.val_pos_edge_index = torch.stack([r, c], dim=0)
+    if attr is not None:
+      a = attr[:n_v]
+      data.val_pos_edge_attr = a
+
     r, c = row[n_v:n_v + n_t], col[n_v:n_v + n_t]
     data.test_pos_edge_index = torch.stack([r, c], dim=0)
+    if attr is not None:
+      a = attr[n_v:n_v + n_t]
+      data.test_pos_edge_attr = a
 
     r, c = row[n_v + n_t:], col[n_v + n_t:]
     data.train_pos_edge_index = torch.stack([r, c], dim=0)
-    data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
-
+    if attr is not None:
+      a = attr[n_v + n_t:]
+      data.train_pos_edge_index, data.train_pos_edge_attr = to_undirected(data.train_pos_edge_index, a)
+    else:
+      data.train_pos_edge_index = to_undirected(data.train_pos_edge_index)
+   
     # Negative edges.
     neg_adj_mask = torch.ones(num_nodes, num_nodes, dtype=torch.uint8)
     neg_adj_mask = neg_adj_mask.triu(diagonal=1).to(torch.bool)


### PR DESCRIPTION
Added functionality for edge attribute splitting for positive edge indexes only, as discussed in #2669. Negative edge attributes are not created because highly dependant on individual use cases.
Now, after calling `train_test_split_edges` the returned `Data` object will also carry `train_pos_edge_attr`, `val_pos_edge_attr` and `test_pos_edge_attr` as attributes.