### PR TITLE
Changes to Mempooling.

### DIFF
--- a/test/nn/pool/test_mem_pool.py
+++ b/test/nn/pool/test_mem_pool.py
@@ -10,10 +10,11 @@ def test_mem_pool():
 
     x = torch.randn(17, 4)
     batch = torch.tensor([0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4])
-    _, mask = to_dense_batch(batch, batch)
+    _, mask = to_dense_batch(x, batch)
 
     out1, S = mpool1(x, batch)
     loss = MemPooling.kl_loss(S)
+    loss.backward()
     out2, _ = mpool2(out1)
 
     assert out1.size() == (5, 2, 8)

--- a/test/nn/pool/test_mem_pool.py
+++ b/test/nn/pool/test_mem_pool.py
@@ -4,17 +4,20 @@ from torch_geometric.utils import to_dense_batch
 
 
 def test_mem_pool():
-    mpool = MemPooling(4, 8, heads=3, num_clusters=2)
-    assert mpool.__repr__() == 'MemPooling(4, 8, heads=3, num_clusters=2)'
+    mpool1 = MemPooling(4, 8, heads=3, num_clusters=2)
+    assert mpool1.__repr__() == 'MemPooling(4, 8, heads=3, num_clusters=2)'
+    mpool2 = MemPooling(8, 4, heads=2, num_clusters=1)
 
     x = torch.randn(17, 4)
     batch = torch.tensor([0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4])
     _, mask = to_dense_batch(batch, batch)
 
-    out, S = mpool(x, batch)
+    out1, S = mpool1(x, batch)
     loss = MemPooling.kl_loss(S)
+    out2, _ = mpool2(out1)
 
-    assert out.size() == (5, 2, 8)
+    assert out1.size() == (5, 2, 8)
+    assert out2.size() == (5, 1, 4)
     assert S[~mask].sum() == 0
     assert S[mask].sum() == x.size(0)
     assert float(loss) > 0

--- a/torch_geometric/nn/pool/mem_pool.py
+++ b/torch_geometric/nn/pool/mem_pool.py
@@ -77,7 +77,9 @@ class MemPooling(torch.nn.Module):
     def forward(self, x: Tensor,
                 batch: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
         """"""
-        x, mask = to_dense_batch(x, batch)
+        x, mask = (to_dense_batch(x, batch) if x.dim() <= 2
+                   else (x, torch.ones((x.shape[0], x.shape[1]), dtype=bool,
+                         device=x.device)))
 
         (B, N, _), H, K = x.size(), self.heads, self.num_clusters
 


### PR DESCRIPTION
Issue:
  Currently it's not straightforward to stack `Mempooling` layers. See code below, the call to mpool2 will throw an error as out1 has shape `B*N*F` but `forward` expects `Nmax*F`. 
  ```
  mpool1 = MemPooling(4, 8, heads=3, num_clusters=2)
  mpool2 = MemPooling(8, 4, heads=2, num_clusters=1)
  out1,_=mpool1(x,batch)
  out2,_=mpool2(out1) # this will throw an error.
  ```
Fix:
This PR fixes that by adding a line to allow dense inputs to forward. Another way to allow stacking would have been to create a `to_sprase_batch` function that does the reverse of `to_dense_batch`. I could create a PR for that if its useful. 