### PR TITLE
mempool kl_loss Bug fix.

### DIFF
--- a/test/nn/pool/test_mem_pool.py
+++ b/test/nn/pool/test_mem_pool.py
@@ -14,7 +14,8 @@ def test_mem_pool():
 
     out1, S = mpool1(x, batch)
     loss = MemPooling.kl_loss(S)
-    loss.backward()
+    with torch.autograd.set_detect_anomaly(True):
+        loss.backward()
     out2, _ = mpool2(out1)
 
     assert out1.size() == (5, 2, 8)


### PR DESCRIPTION
Running below code.
```
mpool1 = MemPooling(4, 8, heads=3, num_clusters=2)

x = torch.randn(17, 4)
batch = torch.tensor([0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4])
_, mask = to_dense_batch(x, batch)

out1, S = mpool1(x, batch)
loss= MemPooling.kl_loss(S)
with torch.autograd.set_detect_anomaly(True): 
    loss.backward() # without set_detec_anomaly gradients are nan.
```
Throws the following error.
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-183-a8c5fdaba4bc> in <module>
      8 loss= MemPooling.kl_loss(S)
      9 with torch.autograd.set_detect_anomaly(True):
---> 10     loss.backward()

/local/mnt/workspace/usr/rishubh/anaconda3/envs/torch16/lib/python3.8/site-packages/torch/tensor.py in backward(self, gradient, retain_graph, create_graph)
    183                 products. Defaults to ``False``.
    184         """
--> 185         torch.autograd.backward(self, gradient, retain_graph, create_graph)
    186 
    187     def register_hook(self, hook):

/local/mnt/workspace/usr/rishubh/anaconda3/envs/torch16/lib/python3.8/site-packages/torch/autograd/__init__.py in backward(tensors, grad_tensors, retain_graph, create_graph, grad_variables)
    123         retain_graph = create_graph
    124 
--> 125     Variable._execution_engine.run_backward(
    126         tensors, grad_tensors, retain_graph, create_graph,
    127         allow_unreachable=True)  # allow_unreachable flag

RuntimeError: Function 'LogBackward' returned nan values in its 0th output.
```
Fixed this by making 2 changes to kl_loss. 
1.  no tensor has a nan value in any intermediate step.
2. probabilities are clamped to 1e-15.