### PR TITLE
Python version to Installation via Binaries docs

### DIFF
--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -13,6 +13,7 @@ Please follow the steps below for a successful installation.
 Installation via Binaries
 -------------------------
 
+Binaries are provided for Python version <= 3.8.
 We provide pip wheels for all major OS/PyTorch/CUDA combinations:
 
 #. Ensure that at least PyTorch 1.4.0 is installed:


### PR DESCRIPTION
**Documentation**

- Add Python version specification when installing PyTorch Geometric via binaries in the Documentation

The Python version required is specified in the README file but not in the docs. 
This addition in the docs aims to minimize the scenario of a user trying to install PyG via binaries following the docs without reading the README file and using a higher Python version, e.g.: the latest Python 3.9.

**Note:** the above situation is based on real events.
