### PR TITLE
SuperGATConv bug?

### DIFF
--- a/torch_geometric/nn/conv/supergat_conv.py
+++ b/torch_geometric/nn/conv/supergat_conv.py
@@ -187,7 +187,7 @@ class SuperGATConv(MessagePassing):
             pos_edge_index = self.positive_sampling(edge_index)
 
             pos_att = self.get_attention(
-                edge_index_i=edge_index[1],
+                edge_index_i=pos_edge_index[1],
                 x_i=x[edge_index[1]],
                 x_j=x[edge_index[0]],
                 num_nodes=x.size(0),

--- a/torch_geometric/nn/conv/supergat_conv.py
+++ b/torch_geometric/nn/conv/supergat_conv.py
@@ -188,8 +188,8 @@ class SuperGATConv(MessagePassing):
 
             pos_att = self.get_attention(
                 edge_index_i=pos_edge_index[1],
-                x_i=x[edge_index[1]],
-                x_j=x[edge_index[0]],
+                x_i=x[pos_edge_index[1]],
+                x_j=x[pos_edge_index[0]],
                 num_nodes=x.size(0),
                 return_logits=True,
             )


### PR DESCRIPTION
I think there might be a typo in the SuperGATConvlayer? I think it should be using the positive supervision edges in the attention calculation, rather than the message passing edges (just like in the calculation of the attention for the negative supervision edges).