### PR TITLE
Transpose the stored transformation matrix in LinearTransformation

### DIFF
--- a/torch_geometric/transforms/linear_transformation.py
+++ b/torch_geometric/transforms/linear_transformation.py
@@ -17,7 +17,9 @@ class LinearTransformation(object):
             'Transformation matrix should be square. Got [{} x {}] rectangular'
             'matrix.'.format(*matrix.size()))
 
-        self.matrix = matrix
+        # Store the matrix as its transpose. We do this to enable the 
+        # postmultiplication in  __call__.
+        self.matrix = matrix.transpose(0, 1)
 
     def __call__(self, data):
         pos = data.pos.view(-1, 1) if data.pos.dim() == 1 else data.pos
@@ -26,6 +28,9 @@ class LinearTransformation(object):
             'Node position matrix and transformation matrix have incompatible '
             'shape.')
 
+        # We postmultiply the points by the transformation matrix of shape [D, D]
+        # instead of premultiplying because data.pos has shape [N, D], and we want
+        # to preserve this shape.
         data.pos = torch.matmul(pos, self.matrix.to(pos.dtype).to(pos.device))
 
         return data


### PR DESCRIPTION
 so that the matrix multiplication matches the expected convention of a linear transformation. See #2772 for discussion.

Tested by running:
```
pytest --no-cov test/transforms/test_linear_transformation.py
```