### PR TITLE
Numerical error in LayerNorm leading to NaN in gradients

### DIFF
--- a/torch_geometric/nn/norm/layer_norm.py
+++ b/torch_geometric/nn/norm/layer_norm.py
@@ -70,7 +70,7 @@ class LayerNorm(torch.nn.Module):
                           reduce='add').sum(dim=-1, keepdim=True)
             var = var / norm
 
-            out = x / (var.sqrt()[batch] + self.eps)
+            out = x / (var + self.eps).sqrt()[batch]
 
         if self.weight is not None and self.bias is not None:
             out = out * self.weight + self.bias


### PR DESCRIPTION
Similar to this issue: https://github.com/rusty1s/pytorch_geometric/issues/2559

Added same fix to `layer_norm`, changing

```
out = x / (var.sqrt()[batch] + self.eps)
```

to 

```
out = x / (var + self.eps).sqrt()[batch]
```