### PR TITLE
Transform Base Class

### DIFF
--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -1,3 +1,4 @@
+from .base_transform import BaseTransform
 from .compose import Compose
 from .to_sparse_tensor import ToSparseTensor
 from .to_undirected import ToUndirected
@@ -42,6 +43,7 @@ from .gcn_norm import GCNNorm
 from .add_train_val_test_mask import AddTrainValTestMask
 
 __all__ = [
+    'BaseTransform',
     'Compose',
     'ToSparseTensor',
     'ToUndirected',

--- a/torch_geometric/transforms/add_self_loops.py
+++ b/torch_geometric/transforms/add_self_loops.py
@@ -1,8 +1,9 @@
 from torch_sparse import coalesce
 from torch_geometric.utils import add_self_loops
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class AddSelfLoops(object):
+class AddSelfLoops(BaseTransform):
     r"""Adds self-loops to edge indices."""
 
     def __call__(self, data):

--- a/torch_geometric/transforms/add_train_val_test_mask.py
+++ b/torch_geometric/transforms/add_train_val_test_mask.py
@@ -1,9 +1,10 @@
 from typing import Union
 
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class AddTrainValTestMask(object):
+class AddTrainValTestMask(BaseTransform):
     r"""Adds a node-level random split via :obj:`train_mask`, :obj:`val_mask`
     and :obj:`test_mask` attributes to the :obj:`data` object.
 

--- a/torch_geometric/transforms/base_transform.py
+++ b/torch_geometric/transforms/base_transform.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+
+
+class BaseTransform(ABC):
+    @abstractmethod
+    def __call__(self, data):
+        pass

--- a/torch_geometric/transforms/cartesian.py
+++ b/torch_geometric/transforms/cartesian.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Cartesian(object):
+class Cartesian(BaseTransform):
     r"""Saves the relative Cartesian coordinates of linked nodes in its edge
     attributes.
 

--- a/torch_geometric/transforms/center.py
+++ b/torch_geometric/transforms/center.py
@@ -1,4 +1,7 @@
-class Center(object):
+from torch_geometric.transforms.base_transform import BaseTransform
+
+
+class Center(BaseTransform):
     r"""Centers node positions around the origin."""
 
     def __call__(self, data):

--- a/torch_geometric/transforms/compose.py
+++ b/torch_geometric/transforms/compose.py
@@ -1,7 +1,8 @@
 from typing import List, Callable
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Compose(object):
+class Compose(BaseTransform):
     """Composes several transforms together.
 
     Args:

--- a/torch_geometric/transforms/constant.py
+++ b/torch_geometric/transforms/constant.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Constant(object):
+class Constant(BaseTransform):
     r"""Adds a constant value to each node feature.
 
     Args:

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -1,8 +1,9 @@
 import torch
 import scipy.spatial
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Delaunay(object):
+class Delaunay(BaseTransform):
     r"""Computes the delaunay triangulation of a set of points."""
     def __call__(self, data):
         if data.pos.size(0) < 2:

--- a/torch_geometric/transforms/distance.py
+++ b/torch_geometric/transforms/distance.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Distance(object):
+class Distance(BaseTransform):
     r"""Saves the Euclidean distance of linked nodes in its edge attributes.
 
     Args:

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -1,8 +1,9 @@
 import torch
 from torch_geometric.utils import to_undirected
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class FaceToEdge(object):
+class FaceToEdge(BaseTransform):
     r"""Converts mesh faces :obj:`[3, num_faces]` to edge indices
     :obj:`[2, num_edges]`.
 

--- a/torch_geometric/transforms/fixed_points.py
+++ b/torch_geometric/transforms/fixed_points.py
@@ -3,9 +3,10 @@ import math
 
 import torch
 import numpy as np
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class FixedPoints(object):
+class FixedPoints(BaseTransform):
     r"""Samples a fixed number of :obj:`num` points and features from a point
     cloud.
 

--- a/torch_geometric/transforms/gcn_norm.py
+++ b/torch_geometric/transforms/gcn_norm.py
@@ -1,7 +1,8 @@
 import torch_geometric
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class GCNNorm(object):
+class GCNNorm(BaseTransform):
     r"""Applies the GCN normalization from the `"Semi-supervised Classification
     with Graph Convolutional Networks" <https://arxiv.org/abs/1609.02907>`_
     paper.

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -4,9 +4,10 @@ from scipy.linalg import expm
 from torch_geometric.utils import add_self_loops, is_undirected, to_dense_adj
 from torch_sparse import coalesce
 from torch_scatter import scatter_add
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class GDC(object):
+class GDC(BaseTransform):
     r"""Processes the graph via Graph Diffusion Convolution (GDC) from the
     `"Diffusion Improves Graph Learning" <https://www.kdd.in.tum.de/gdc>`_
     paper.

--- a/torch_geometric/transforms/generate_mesh_normals.py
+++ b/torch_geometric/transforms/generate_mesh_normals.py
@@ -1,9 +1,10 @@
 import torch
 import torch.nn.functional as F
 from torch_scatter import scatter_add
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class GenerateMeshNormals(object):
+class GenerateMeshNormals(BaseTransform):
     r"""Generate normal vectors for each mesh node based on neighboring
     faces."""
 

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -4,9 +4,10 @@ import torch
 import torch.nn.functional as F
 from torch_scatter import scatter_add, scatter_mean
 import torch_geometric
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class GridSampling(object):
+class GridSampling(BaseTransform):
     r"""Clusters points into voxels with size :attr:`size`.
 
     Args:

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,8 +1,9 @@
 import torch_geometric
 from torch_geometric.utils import to_undirected
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class KNNGraph(object):
+class KNNGraph(BaseTransform):
     r"""Creates a k-NN graph based on node positions :obj:`pos`.
 
     Args:

--- a/torch_geometric/transforms/laplacian_lambda_max.py
+++ b/torch_geometric/transforms/laplacian_lambda_max.py
@@ -1,8 +1,9 @@
 from scipy.sparse.linalg import eigs, eigsh
 from torch_geometric.utils import get_laplacian, to_scipy_sparse_matrix
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class LaplacianLambdaMax(object):
+class LaplacianLambdaMax(BaseTransform):
     r"""Computes the highest eigenvalue of the graph Laplacian given by
     :meth:`torch_geometric.utils.get_laplacian`.
 

--- a/torch_geometric/transforms/line_graph.py
+++ b/torch_geometric/transforms/line_graph.py
@@ -2,9 +2,10 @@ import torch
 from torch_sparse import coalesce
 from torch_scatter import scatter_add
 from torch_geometric.utils import remove_self_loops
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class LineGraph(object):
+class LineGraph(BaseTransform):
     r"""Converts a graph to its corresponding line-graph:
 
     .. math::

--- a/torch_geometric/transforms/linear_transformation.py
+++ b/torch_geometric/transforms/linear_transformation.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class LinearTransformation(object):
+class LinearTransformation(BaseTransform):
     r"""Transforms node positions with a square transformation matrix computed
     offline.
 

--- a/torch_geometric/transforms/local_cartesian.py
+++ b/torch_geometric/transforms/local_cartesian.py
@@ -1,8 +1,9 @@
 import torch
 from torch_scatter import scatter_max
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class LocalCartesian(object):
+class LocalCartesian(BaseTransform):
     r"""Saves the relative Cartesian coordinates of linked nodes in its edge
     attributes. Each coordinate gets *neighborhood-normalized* to the
     interval :math:`{[0, 1]}^D`.

--- a/torch_geometric/transforms/local_degree_profile.py
+++ b/torch_geometric/transforms/local_degree_profile.py
@@ -1,9 +1,10 @@
 import torch
 from torch_scatter import scatter_min, scatter_max, scatter_mean, scatter_std
 from torch_geometric.utils import degree
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class LocalDegreeProfile(object):
+class LocalDegreeProfile(BaseTransform):
     r"""Appends the Local Degree Profile (LDP) from the `"A Simple yet
     Effective Baseline for Non-attribute Graph Classification"
     <https://arxiv.org/abs/1811.03508>`_ paper

--- a/torch_geometric/transforms/normalize_features.py
+++ b/torch_geometric/transforms/normalize_features.py
@@ -1,4 +1,7 @@
-class NormalizeFeatures(object):
+from torch_geometric.transforms.base_transform import BaseTransform
+
+
+class NormalizeFeatures(BaseTransform):
     r"""Row-normalizes node features to sum-up to one."""
 
     def __call__(self, data):

--- a/torch_geometric/transforms/normalize_rotation.py
+++ b/torch_geometric/transforms/normalize_rotation.py
@@ -1,8 +1,9 @@
 import torch
 import torch.nn.functional as F
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class NormalizeRotation(object):
+class NormalizeRotation(BaseTransform):
     r"""Rotates all points according to the eigenvectors of the point cloud.
     If the data additionally holds normals saved in :obj:`data.normal`, these
     will be rotated accordingly.

--- a/torch_geometric/transforms/normalize_scale.py
+++ b/torch_geometric/transforms/normalize_scale.py
@@ -1,7 +1,8 @@
 from torch_geometric.transforms import Center
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class NormalizeScale(object):
+class NormalizeScale(BaseTransform):
     r"""Centers and normalizes node positions to the interval :math:`(-1, 1)`.
     """
 

--- a/torch_geometric/transforms/one_hot_degree.py
+++ b/torch_geometric/transforms/one_hot_degree.py
@@ -1,9 +1,10 @@
 import torch
 import torch.nn.functional as F
 from torch_geometric.utils import degree
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class OneHotDegree(object):
+class OneHotDegree(BaseTransform):
     r"""Adds the node degree as one hot encodings to the node features.
 
     Args:

--- a/torch_geometric/transforms/point_pair_features.py
+++ b/torch_geometric/transforms/point_pair_features.py
@@ -1,8 +1,9 @@
 import torch
 import torch_geometric
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class PointPairFeatures(object):
+class PointPairFeatures(BaseTransform):
     r"""Computes the rotation-invariant Point Pair Features
 
     .. math::

--- a/torch_geometric/transforms/polar.py
+++ b/torch_geometric/transforms/polar.py
@@ -1,9 +1,10 @@
 from math import pi as PI
 
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Polar(object):
+class Polar(BaseTransform):
     r"""Saves the polar coordinates of linked nodes in its edge attributes.
 
     Args:

--- a/torch_geometric/transforms/radius_graph.py
+++ b/torch_geometric/transforms/radius_graph.py
@@ -1,7 +1,8 @@
 import torch_geometric
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RadiusGraph(object):
+class RadiusGraph(BaseTransform):
     r"""Creates edges based on node positions :obj:`pos` to all points within a
     given distance.
 

--- a/torch_geometric/transforms/random_flip.py
+++ b/torch_geometric/transforms/random_flip.py
@@ -1,7 +1,8 @@
 import random
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RandomFlip(object):
+class RandomFlip(BaseTransform):
     """Flips node positions along a given axis randomly with a given
     probability.
 

--- a/torch_geometric/transforms/random_rotate.py
+++ b/torch_geometric/transforms/random_rotate.py
@@ -4,9 +4,10 @@ import math
 
 import torch
 from torch_geometric.transforms import LinearTransformation
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RandomRotate(object):
+class RandomRotate(BaseTransform):
     r"""Rotates node positions around a specific axis by a randomly sampled
     factor within a given interval.
 

--- a/torch_geometric/transforms/random_scale.py
+++ b/torch_geometric/transforms/random_scale.py
@@ -1,7 +1,8 @@
 import random
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RandomScale(object):
+class RandomScale(BaseTransform):
     r"""Scales node positions by a randomly sampled factor :math:`s` within a
     given interval, *e.g.*, resulting in the transformation matrix
 

--- a/torch_geometric/transforms/random_shear.py
+++ b/torch_geometric/transforms/random_shear.py
@@ -1,8 +1,9 @@
 import torch
 from torch_geometric.transforms import LinearTransformation
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RandomShear(object):
+class RandomShear(BaseTransform):
     r"""Shears node positions by randomly sampled factors :math:`s` within a
     given interval, *e.g.*, resulting in the transformation matrix
 

--- a/torch_geometric/transforms/random_translate.py
+++ b/torch_geometric/transforms/random_translate.py
@@ -2,9 +2,10 @@ import numbers
 from itertools import repeat
 
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RandomTranslate(object):
+class RandomTranslate(BaseTransform):
     r"""Translates node positions by randomly sampled translation values
     within a given interval. In contrast to other random transformations,
     translation is applied separately at each position.

--- a/torch_geometric/transforms/remove_isolated_nodes.py
+++ b/torch_geometric/transforms/remove_isolated_nodes.py
@@ -2,9 +2,10 @@ import re
 
 import torch
 from torch_geometric.utils import remove_isolated_nodes
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class RemoveIsolatedNodes(object):
+class RemoveIsolatedNodes(BaseTransform):
     r"""Removes isolated nodes from the graph."""
     def __call__(self, data):
         num_nodes = data.num_nodes

--- a/torch_geometric/transforms/sample_points.py
+++ b/torch_geometric/transforms/sample_points.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class SamplePoints(object):
+class SamplePoints(BaseTransform):
     r"""Uniformly samples :obj:`num` points on the mesh faces according to
     their face area.
 

--- a/torch_geometric/transforms/sign.py
+++ b/torch_geometric/transforms/sign.py
@@ -1,8 +1,9 @@
 import torch
 from torch_sparse import SparseTensor
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class SIGN(object):
+class SIGN(BaseTransform):
     r"""The Scalable Inception Graph Neural Network module (SIGN) from the
     `"SIGN: Scalable Inception Graph Neural Networks"
     <https://arxiv.org/abs/2004.11198>`_ paper, which precomputes the fixed

--- a/torch_geometric/transforms/spherical.py
+++ b/torch_geometric/transforms/spherical.py
@@ -1,9 +1,10 @@
 from math import pi as PI
 
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class Spherical(object):
+class Spherical(BaseTransform):
     r"""Saves the spherical coordinates of linked nodes in its edge attributes.
 
     Args:

--- a/torch_geometric/transforms/target_indegree.py
+++ b/torch_geometric/transforms/target_indegree.py
@@ -1,8 +1,9 @@
 import torch
 from torch_geometric.utils import degree
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class TargetIndegree(object):
+class TargetIndegree(BaseTransform):
     r"""Saves the globally normalized degree of target nodes
 
     .. math::

--- a/torch_geometric/transforms/to_dense.py
+++ b/torch_geometric/transforms/to_dense.py
@@ -1,7 +1,8 @@
 import torch
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class ToDense(object):
+class ToDense(BaseTransform):
     r"""Converts a sparse adjacency matrix to a dense adjacency matrix with
     shape :obj:`[num_nodes, num_nodes, *]`.
 

--- a/torch_geometric/transforms/to_sparse_tensor.py
+++ b/torch_geometric/transforms/to_sparse_tensor.py
@@ -1,7 +1,8 @@
 from torch_sparse import SparseTensor
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class ToSparseTensor(object):
+class ToSparseTensor(BaseTransform):
     r"""Converts the :obj:`edge_index` attribute of a data object into a
     (transposed) :class:`torch_sparse.SparseTensor` type with key
     :obj:`adj_.t`.

--- a/torch_geometric/transforms/to_superpixels.py
+++ b/torch_geometric/transforms/to_superpixels.py
@@ -1,9 +1,10 @@
 import torch
 from torch_scatter import scatter_mean
 from torch_geometric.data import Data
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class ToSLIC(object):
+class ToSLIC(BaseTransform):
     r"""Converts an image to a superpixel representation using the
     :meth:`skimage.segmentation.slic` algorithm, resulting in a
     :obj:`torch_geometric.data.Data` object holding the centroids of

--- a/torch_geometric/transforms/to_undirected.py
+++ b/torch_geometric/transforms/to_undirected.py
@@ -1,7 +1,8 @@
 from torch_geometric.utils import to_undirected
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class ToUndirected(object):
+class ToUndirected(BaseTransform):
     r"""Converts the graph to an undirected graph, so that
     :math:`(j,i) \in \mathcal{E}` for every edge :math:`(i,j) \in \mathcal{E}`.
 

--- a/torch_geometric/transforms/two_hop.py
+++ b/torch_geometric/transforms/two_hop.py
@@ -2,9 +2,10 @@ import torch
 from torch_sparse import spspmm, coalesce
 
 from torch_geometric.utils import remove_self_loops
+from torch_geometric.transforms.base_transform import BaseTransform
 
 
-class TwoHop(object):
+class TwoHop(BaseTransform):
     r"""Adds the two hop edges to the edge indices."""
     def __call__(self, data):
         edge_index, edge_attr = data.edge_index, data.edge_attr


### PR DESCRIPTION
As per https://github.com/rusty1s/pytorch_geometric/discussions/2903:

Enables typechecking/linting on Transform objects by inheriting from a common class other than `object`. 

```python
# current:
from typing import Callable

def run(transform: Callable):
	T.Compose([transform])
	
run(abs) # callable, but not a transform

# proposed:
from torch_geometric.transforms.base_transform import BaseTransform

def run(transform: BaseTransform): # all transforms inherit from common class
	T.Compose([transform])

run(T.RandomScale()) # okay
run(abs) # throws linter error
```

Would you want me to update typing references for `Callable` to `BaseTransform` as well?