### PR TITLE
Correct gini coefficient mathcal formula

### DIFF
--- a/torch_geometric/nn/functional/gini.py
+++ b/torch_geometric/nn/functional/gini.py
@@ -10,7 +10,7 @@ def gini(w: torch.Tensor) -> torch.Tensor:
 
     .. math::
         \mathcal{L}_\textrm{Gini}^i = \sum_j^n \sum_{j'}^n \frac{|w_{ij}
-         - w_{ij'}|}{(2 n^2 - n)\bar{w_i}}
+         - w_{ij'}|}{2 (n^2 - n)\bar{w_i}}
 
     And returns an average over all rows.
 


### PR DESCRIPTION
/cc @rhsimplex @Jostarndt

Current formula
<img width="261" alt="Screen Shot 2021-08-01 at 22 00 47" src="https://user-images.githubusercontent.com/2758453/127783840-76beef2b-f92c-4dcb-8f4e-41188681525a.png">


PR suggestion:
<img width="298" alt="Screen Shot 2021-08-01 at 22 00 28" src="https://user-images.githubusercontent.com/2758453/127783808-d3013b58-b784-430d-a86a-5b4c22cc8475.png">

For a set {1,0}, my napkin math results in an expected Gini coefficient of 1 for the proposed formula.
