### PR TITLE
Make informational `print`s go to stderr

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Callable, Union, Any, Tuple
 
+import sys
 import re
 import copy
 import warnings
@@ -159,7 +160,7 @@ class Dataset(torch.utils.data.Dataset):
         if files_exist(self.processed_paths):  # pragma: no cover
             return
 
-        print('Processing...')
+        print('Processing...', file=sys.stderr)
 
         makedirs(self.processed_dir)
         self.process()
@@ -169,7 +170,7 @@ class Dataset(torch.utils.data.Dataset):
         path = osp.join(self.processed_dir, 'pre_filter.pt')
         torch.save(_repr(self.pre_filter), path)
 
-        print('Done!')
+        print('Done!', file=sys.stderr)
 
     def __len__(self) -> int:
         r"""The number of examples in the dataset."""


### PR DESCRIPTION
Currently, `Dataset` prints out
```
Processing...
Done!
```
when processing a dataset. This is useful feedback for the user (usually), but goes to `stdout`, corrupting the output of scripts that depend on it. (I am trying to build a UNIX-style script where messages go to `stderr` and only the machine readable output goes to `stdout` for easy piping into a file or other tool.)

This PR switches those `print` statements to print to stderr instead. Two other options are:
 1. Use Python's built-in `logging` to give the user full control of these messages
 2. Do not emit these updates at all

Searching, this seems to be the only place in the code that uses `print`.