### PR TITLE
support `del data["key"]` in `Data`

### DIFF
--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -126,6 +126,10 @@ class Data(object):
         """Sets the attribute :obj:`key` to :obj:`value`."""
         setattr(self, key, value)
 
+    def __delitem__(self, key):
+        r"""Delete the data of the attribute :obj:`key`."""
+        return delattr(self, key)
+
     @property
     def keys(self):
         r"""Returns all names of graph attributes."""


### PR DESCRIPTION
Currently the only way to remove a key from a `Data` object is by calling `delattr`, which somewhat breaks the abstraction of `Data` being `dict`-like and only using the `*attr` methods as an internal implementation detail.

This PR adds a `__delitem__` method to `Data` completing the `dict`-like interface.