### PR TITLE
Homophily batch support.

### DIFF
--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -3,7 +3,9 @@ from torch_geometric.utils import homophily
 
 
 def test_homophily():
-    edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
-    y = torch.tensor([0, 0, 0])
-    assert homophily(edge_index, y, method='edge') == 1.
-    assert homophily(edge_index, y.unsqueeze(1), method='node') == 1.
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 0, 4]])
+    y = torch.tensor([0, 0, 0, 0, 1])
+    batch = torch.tensor([0, 0, 0, 1, 1])
+    assert homophily(edge_index, y, method='edge') == 0.75
+    assert homophily(edge_index, y, batch, method='edge').tolist() == [1.,0.]
+    assert homophily(edge_index, y.unsqueeze(1), method='node') == 0.6

--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -9,3 +9,4 @@ def test_homophily():
     assert homophily(edge_index, y, method='edge') == 0.75
     assert homophily(edge_index, y, batch, method='edge').tolist() == [1.,0.]
     assert homophily(edge_index, y.unsqueeze(1), method='node') == 0.6
+    assert homophily(edge_index, y.unsqueeze(1), batch, method='node').tolist() == [1.,0.]

--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -7,6 +7,7 @@ def test_homophily():
     y = torch.tensor([0, 0, 0, 0, 1])
     batch = torch.tensor([0, 0, 0, 1, 1])
     assert homophily(edge_index, y, method='edge') == 0.75
-    assert homophily(edge_index, y, batch, method='edge').tolist() == [1.,0.]
+    assert homophily(edge_index, y, batch, method='edge').tolist() == [1., 0.]
     assert homophily(edge_index, y.unsqueeze(1), method='node') == 0.6
-    assert homophily(edge_index, y.unsqueeze(1), batch, method='node').tolist() == [1.,0.]
+    assert homophily(edge_index, y.unsqueeze(1), batch,
+                     method='node').tolist() == [1., 0.]

--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -1,4 +1,5 @@
 import torch
+from torch_sparse import SparseTensor
 from torch_geometric.utils import homophily
 
 
@@ -6,8 +7,13 @@ def test_homophily():
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 0, 4]])
     y = torch.tensor([0, 0, 0, 0, 1])
     batch = torch.tensor([0, 0, 0, 1, 1])
+    row, col = edge_index
+    adj = SparseTensor(row=row, col=col, sparse_sizes=(5, 5))
+
     assert homophily(edge_index, y, method='edge') == 0.75
+    assert homophily(adj, y, method='edge') == 0.75
     assert homophily(edge_index, y, batch, method='edge').tolist() == [1., 0.]
     assert homophily(edge_index, y.unsqueeze(1), method='node') == 0.6
+    assert homophily(adj, y.unsqueeze(1), method='node') == 0.6
     assert homophily(edge_index, y.unsqueeze(1), batch,
                      method='node').tolist() == [1., 0.]

--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -1,3 +1,5 @@
+import pytest
+
 import torch
 from torch_sparse import SparseTensor
 from torch_geometric.utils import homophily
@@ -10,10 +12,10 @@ def test_homophily():
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(5, 5))
 
-    assert homophily(edge_index, y, method='edge') == 0.75
-    assert homophily(adj, y, method='edge') == 0.75
+    assert pytest.approx(homophily(edge_index, y, method='edge')) == 0.75
+    assert pytest.approx(homophily(adj, y, method='edge')) == 0.75
     assert homophily(edge_index, y, batch, method='edge').tolist() == [1., 0.]
-    assert homophily(edge_index, y.unsqueeze(1), method='node') == 0.6
-    assert homophily(adj, y.unsqueeze(1), method='node') == 0.6
-    assert homophily(edge_index, y.unsqueeze(1), batch,
-                     method='node').tolist() == [1., 0.]
+
+    assert pytest.approx(homophily(edge_index, y, method='node')) == 0.6
+    assert pytest.approx(homophily(adj, y, method='node')) == 0.6
+    assert homophily(edge_index, y, batch, method='node').tolist() == [1., 0.]

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -81,11 +81,11 @@ def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
     if method == 'edge':
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
-        return (out.mean() if batch is None else scatter_mean(
+        return (float(out.mean()) if batch is None else scatter_mean(
             out, batch[col], 0, dim_size=batch_size))
     else:
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
         out = scatter_mean(out, col, 0, dim_size=y.size(0))
-        return (out.mean() if batch is None else scatter_mean(
+        return (float(out.mean()) if batch is None else scatter_mean(
             out, batch, 0, dim_size=batch_size))

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -68,6 +68,7 @@ def homophily(edge_index: Adj, y: Tensor, batch:OptTensor = None,
     """
     assert method in ['edge', 'node']
     y = y.squeeze(-1) if y.dim() > 1 else y
+    batch_size = 1 if batch is None else batch.unique().size(0)
 
     if isinstance(edge_index, SparseTensor):
         col, row, _ = edge_index.coo()
@@ -78,9 +79,10 @@ def homophily(edge_index: Adj, y: Tensor, batch:OptTensor = None,
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
         return (out.mean() if batch is None else 
-                scatter_mean(out, batch[col], 0, dim_size= batch.unique().size(0)))
+                scatter_mean(out, batch[col], 0, dim_size= batch_size))
     else:
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
         out = scatter_mean(out, col, 0, dim_size=y.size(0))
-        return float(out.mean())
+        return (out.mean() if batch is None else 
+                scatter_mean(out, batch, 0, dim_size= batch_size))

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -11,15 +11,18 @@ def homophily(adj_t, y, batch, method):
     # type: (SparseTensor, Tensor) -> float
     pass
 
+
 @torch.jit._overload
 def homophily(adj_t, y, batch, method):
     # type: (SparseTensor, Tensor, OptTensor) -> Tensor
     pass
 
+
 @torch.jit._overload
 def homophily(edge_index, y, batch, method):
     # type: (Tensor, Tensor) -> float
     pass
+
 
 @torch.jit._overload
 def homophily(edge_index, y, batch, method):
@@ -27,7 +30,7 @@ def homophily(edge_index, y, batch, method):
     pass
 
 
-def homophily(edge_index: Adj, y: Tensor, batch:OptTensor = None, 
+def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
               method: str = 'edge'):
     r"""The homophily of a graph characterizes how likely nodes with the same
     label are near each other in a graph.
@@ -59,9 +62,9 @@ def homophily(edge_index: Adj, y: Tensor, batch:OptTensor = None,
     Args:
         edge_index (Tensor or SparseTensor): The graph connectivity.
         y (Tensor): The labels.
-        batch (LongTensor, optional): Batch vector :math:`\mathbf{b} \in {\{ 0, \ldots,
-            B-1\}}^N`, which assigns each node to a specific example.
-            (default: :obj:`None`)
+        batch (LongTensor, optional): Batch vector
+            :math:`\mathbf{b} \in {\{ 0, \ldots,B-1\}}^N`, which assigns
+            each node to a specific example. (default: :obj:`None`)
         method (str, optional): The method used to calculate the homophily,
             either :obj:`"edge"` (first formula) or :obj:`"node"`
             (second formula). (default: :obj:`"edge"`)
@@ -78,11 +81,11 @@ def homophily(edge_index: Adj, y: Tensor, batch:OptTensor = None,
     if method == 'edge':
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
-        return (out.mean() if batch is None else 
-                scatter_mean(out, batch[col], 0, dim_size= batch_size))
+        return (out.mean() if batch is None else scatter_mean(
+            out, batch[col], 0, dim_size=batch_size))
     else:
         out = torch.zeros_like(row, dtype=float)
         out[y[row] == y[col]] = 1.
         out = scatter_mean(out, col, 0, dim_size=y.size(0))
-        return (out.mean() if batch is None else 
-                scatter_mean(out, batch, 0, dim_size= batch_size))
+        return (out.mean() if batch is None else scatter_mean(
+            out, batch, 0, dim_size=batch_size))


### PR DESCRIPTION
#3028
This PR updates `torch_geometric.utils.homophily`. `homophily` can now be called with `batch`.