### PR TITLE
Fix:Replace to_undirected() with coalesce().

### DIFF
--- a/torch_geometric/datasets/wikipedia_network.py
+++ b/torch_geometric/datasets/wikipedia_network.py
@@ -5,6 +5,7 @@ import os.path as osp
 import torch
 import numpy as np
 
+from torch_sparse import coalesce
 from torch_geometric.utils import to_undirected
 from torch_geometric.data import InMemoryDataset, download_url, Data
 
@@ -105,7 +106,7 @@ class WikipediaNetwork(InMemoryDataset):
                 data = f.read().split('\n')[1:-1]
                 data = [[int(v) for v in r.split('\t')] for r in data]
             edge_index = torch.tensor(data, dtype=torch.long).t().contiguous()
-            edge_index = to_undirected(edge_index, num_nodes=x.size(0))
+            edge_index, _ = coalesce(edge_index, None, x.size(0), x.size(0))
 
             train_masks, val_masks, test_masks = [], [], []
             for filepath in self.raw_paths[2:]:


### PR DESCRIPTION
The issue #2979 fixed in commit https://github.com/rusty1s/pytorch_geometric/commit/665c5dad47884eeb5738478db99d75dec85b1816 still cause different benchmark result on dataset chameleon or squirrel. This problem is caused by changing function coalesce() to to_undirected(). It may be needed to reset to_undirected() to coalesce() in order to keep the API layer compatibility.